### PR TITLE
Tweaks for terminal code blocks

### DIFF
--- a/pages/cli.mdx
+++ b/pages/cli.mdx
@@ -11,14 +11,14 @@ The [Avo command line interface](https://github.com/avohq/avo) provides a way to
 ### Step 1: Install the Avo CLI
 
 ```bash
-npm install -g avo
+$ npm install -g avo
 ```
 
 After installing, verify everything is in working order by running `avo --version`.
 
 ```bash
-avo --version
-> 1.3.6
+$ avo --version
+1.3.6
 ```
 
 ### Step 2: Link your Avo account
@@ -26,14 +26,14 @@ avo --version
 Once you have installed the Avo CLI, run `avo login` to link your Avo account with the CLI.
 
 ```bash
-avo login
+$ avo login
 ```
 
 After you have successfully linked your account, run `avo whoami` to see the linked account.
 
 ```bash
-avo whoami
-> Logged in as my@account.com
+$ avo whoami
+Logged in as my@account.com
 ```
 
 ### Step 3: Pull generated analytics wrappers from Avo
@@ -45,7 +45,7 @@ When you run this command for the first time it will prompt you to select which 
 Please commit the `avo.json` file into your version control, in order to keep it in sync across your team.
 
 ```bash
-avo pull
+$ avo pull
 ```
 
 ### Step 4: Monitor the analytics implementation
@@ -55,7 +55,7 @@ Once you have implemented analytics with the Avo analytics wrappers, you can che
 The `status` command will report on where the analytics functions provided by Avo are being called, and which events have not been implemented yet.
 
 ```bash
-avo status
+$ avo status
 ```
 
 ## Using Avo Branches
@@ -63,13 +63,13 @@ avo status
 When editing your tracking plan on avo.app you can branch out from the master tracking plan to make changes in isolation, just like with git. To pull analytics wrappers from an open Avo branch you first need to switch to that branch with `avo checkout`.
 
 ```bash
-avo checkout my-branch-name
+$ avo checkout my-branch-name
 ```
 
 You can also pull from a specific branch by using the `--branch` flag when running `avo pull`
 
 ```bash
-avo pull [my-source-name] --branch my-branch-name
+$ avo pull [my-source-name] --branch my-branch-name
 ```
 
 ### Using an Avo branch with a git branch
@@ -79,14 +79,14 @@ Here is the workflow we recommend when working on Avo branches with git branches
 1. On your git branch, pull updated analytics wrappers from the Avo branch you would like to implement
 
 ```bash
-avo pull [my-source-name] --branch my-branch-name
+$ avo pull [my-source-name] --branch my-branch-name
 ```
 
 2. Once ready to merge, make sure your Avo branch is up to date with Avo master by pulling latest master changes into your branch. This can also be done from the branch review screen on avo.app.
    If any changes were pulled in, make sure to run `avo pull` again to update the analytics wrappers
 
 ```bash
-avo merge master
+$ avo merge master
 ```
 
 3. Review and merge your git branch
@@ -98,13 +98,13 @@ avo merge master
 To resolve git conflicts in `avo.json` run `avo pull`. It will attempt to resolve the git conflicts in `avo.json` automatically and check whether the incoming branch has been merge and if your current branch is up to date with Avo master before pulling latest analytics wrappers.
 
 ```bash
-avo pull
+$ avo pull
 ```
 
 As an alternative you can also run `avo conflict`, it will resolve any conflicts in `avo.json` without pulling latest analytics wrappers.
 
 ```bash
-avo conflict
+$ avo conflict
 ```
 
 ## Complete Reference

--- a/pages/commands.mdx
+++ b/pages/commands.mdx
@@ -11,14 +11,14 @@ The [Avo command line interface](https://github.com/avohq/avo) provides a way to
 ### Step 1: Install the Avo CLI
 
 ```sh
-npm install -g avo
+$ npm install -g avo
 ```
 
 After installing, verify everything is in working order by running `avo --version`
 
 ```sh
-avo --version
-> 1.3.6
+$ avo --version
+1.3.6
 ```
 
 ### Step 2: Link your Avo account
@@ -26,14 +26,14 @@ avo --version
 Once you have installed the Avo CLI, run `avo login` to link your Avo account with the CLI.
 
 ```sh
-avo login
+$ avo login
 ```
 
 After you have successfully linked your account, run `avo whoami` to see the linked account.
 
 ```sh
-avo whoami
-> Logged in as my@account.com
+$ avo whoami
+Logged in as my@account.com
 ```
 
 ### Step 3: Pull generated analytics wrappers from Avo
@@ -45,7 +45,7 @@ When you run this command for the first time it will prompt you to select which 
 Please commit the `avo.json` file into your version control, in order to keep it in sync across your team.
 
 ```sh
-avo pull
+$ avo pull
 ```
 
 ### Step 4: Monitor the analytics implementation
@@ -55,7 +55,7 @@ Once you have implemented analytics with the Avo analytics wrappers, you can che
 The `status` command will report on where the analytics functions provided by Avo are being called, and which events have not been implemented yet.
 
 ```sh
-avo status
+$ avo status
 ```
 
 ## <a name="using-branches"></a> Using Avo Branches
@@ -63,13 +63,13 @@ avo status
 When editing your tracking plan on avo.app you can branch out from the master tracking plan to make changes in isolation, just like with git. To pull analytics wrappers from an open Avo branch you first need to switch to that branch with `avo checkout`.
 
 ```sh
-avo checkout my-branch-name
+$ avo checkout my-branch-name
 ```
 
 You can also pull from a specific branch by using the `--branch` flag when running `avo pull`
 
 ```sh
-avo pull [my-source-name] --branch my-branch-name
+$ avo pull [my-source-name] --branch my-branch-name
 ```
 
 ### Using an Avo branch with a git branch
@@ -79,14 +79,14 @@ Here is the workflow we recommend when working on Avo branches with git branches
 1. On your git branch, pull updated analytics wrappers from the Avo branch you would like to implement
 
 ```sh
-avo pull [my-source-name] --branch my-branch-name
+$ avo pull [my-source-name] --branch my-branch-name
 ```
 
 2. Once ready to merge, make sure your Avo branch is up to date with Avo master by pulling latest master changes into your branch. This can also be done from the branch review screen on avo.app.
    If any changes were pulled in, make sure to run `avo pull` again to update the analytics wrappers
 
 ```sh
-avo merge master
+$ avo merge master
 ```
 
 3. Review and merge your git branch
@@ -98,13 +98,13 @@ avo merge master
 To resolve git conflicts in `avo.json` run `avo pull`. It will attempt to resolve the git conflicts in `avo.json` automatically and check whether the incoming branch has been merge and if your current branch is up to date with Avo master before pulling latest analytics wrappers.
 
 ```sh
-avo pull
+$ avo pull
 ```
 
 As an alternative you can also run `avo conflict`, it will resolve any conflicts in `avo.json` without pulling latest analytics wrappers.
 
 ```sh
-avo conflict
+$ avo conflict
 ```
 
 ## <a name="complete-reference"></a> Complete Reference
@@ -113,6 +113,7 @@ Below is the complete documentation for all available commands:
 
 ```sh
 $ avo --help
+
 avo command
 
 Commands:

--- a/pages/inspector/sdk/js.mdx
+++ b/pages/inspector/sdk/js.mdx
@@ -14,7 +14,7 @@ Find the Quick Start Guide in our <a target="_blank" rel="noopener noreferrer" h
 The Inspector library is available through npm. Run the following command to install it:
 
 ```bash
-yarn add avo-inspector
+$ yarn add avo-inspector
 ```
 
 ## <a name="initialization"></a>Initialization

--- a/styles/MDComponents.tsx
+++ b/styles/MDComponents.tsx
@@ -7,6 +7,8 @@ import styles from './MDComponents.module.scss';
 import classNames from 'classnames';
 import throttle from 'lodash.throttle';
 import CodeHeader from '../components/CodeHeader';
+import Avo from '../Avo';
+import useAvoPath from '../util/useAvoPath';
 
 const P: FunctionComponent = (props) => <p className={styles.p} {...props} />;
 const H1: FunctionComponent = (props) => (
@@ -103,6 +105,7 @@ const Code: FunctionComponent<{
     return <code className={className || undefined}>{children}</code>;
   }
   const [shadowOpacity, setShadowOpacity] = useState(0);
+  const avoPath = useAvoPath();
 
   const scrollContainer = useRef<HTMLDivElement>(null);
   const onScrollThrottled = useRef(
@@ -124,7 +127,15 @@ const Code: FunctionComponent<{
   const code = processLines(lines, isTerminal);
 
   const onCopy = useCallback(() => {
-    navigator.clipboard.writeText(rawCode);
+    const code = lines
+      .flatMap((line) => (line.startsWith('$ ') ? [line.substr(2)] : []))
+      .join('\n');
+
+    navigator.clipboard.writeText(code);
+    Avo.contentCopied({
+      path: avoPath,
+      content: code,
+    });
   }, [rawCode]);
 
   return (


### PR DESCRIPTION
### Changes: 

- No more line numbers for terminal code blocks
- Lines prefixed with '$ ' are treated as input, all others as output

![image](https://user-images.githubusercontent.com/3050355/88401092-cfab2d80-cdb8-11ea-95ad-f46c5719e8d9.png)
