### PR TITLE
Fixing links and footer overlap bug

### DIFF
--- a/components/Footer.module.scss
+++ b/components/Footer.module.scss
@@ -5,6 +5,7 @@
 
   padding-bottom: 40px;
   margin-top: 30px;
+  margin-bottom: 60px;
 }
 
 .col {

--- a/pages/workspace/tracking-plan.mdx
+++ b/pages/workspace/tracking-plan.mdx
@@ -16,9 +16,9 @@ An event is defined in the Events section of the Tracking plan and can be organi
 
 - A descriptive _Event Name_
 - A _Description_ including the timing of when the event should be sent as well as other useful implementation details
-- The <Link passHref href="/workspace/connections#sources">_Source(s)_</Link> that the event should be sent from
-- The <Link passHref href="/workspace/workspace#actions">_Actions(s)_</Link> associated with the event
-- The <Link passHref href="/workspace/workspace#metrics">_Metrics(s)_</Link> related to the event
+- The <a href="/workspace/connections#sources">_Source(s)_</a> that the event should be sent from
+- The <a href="#actions">_Actions(s)_</a> associated with the event
+- The <a href="#metrics">_Metrics(s)_</a> related to the event
 - The _category(s)_ that the event is a part of
 
 ### <a name="actions"></a> Actions


### PR DESCRIPTION
- Adjust link styles to use `<a>` instead of `<Link>` to fix link display bugs: https://app.asana.com/0/1151180207914793/1197935172400232
- Fixed two link references that were broken
- Added `margin-bottom: 60px;` to Footer in order to fix overlap bug: https://app.asana.com/0/1151180207914793/1198204324541454

![image](https://user-images.githubusercontent.com/275617/95895637-cf7b5800-0d3f-11eb-828c-947dad2db957.png)