### PR TITLE
Add optional to property required docs for SEO purposes

### DIFF
--- a/pages/workspace/tracking-plan/properties.mdx
+++ b/pages/workspace/tracking-plan/properties.mdx
@@ -89,8 +89,7 @@ Properties values can also be a list of the above mentioned types:
 - [1.2, 1.3, 1.6]
 - [true, false, true, true, false]
 
-
-### <a name="property-presence-configuration"></a> Configuring when Properties are required
+### <a name="property-presence-configuration"></a> Configuring when Properties are required or optional
 
 You can configure when Properties are required on a per-event and per-source basis. That means Avo will not give you an error if that property is missing from an event or source which the property is attached to, in other words it will sometimes be sent.
 
@@ -113,4 +112,3 @@ For configuring per-event and per-source you can change the overall setting for 
     alt="Image shows how to change property presence between events"
   />
 </center>
-


### PR DESCRIPTION
After this change, when people search for "optional" they will see the property absence docs