### PR TITLE
Fix publishing title ids

### DIFF
--- a/pages/workspace/tracking-plan/publishing.mdx
+++ b/pages/workspace/tracking-plan/publishing.mdx
@@ -66,7 +66,7 @@ You can customize which events in Avo are published to which integrations by usi
   style={{ margin: '32px 0 -32px 0' }}
 />
 
-## <a name="segment-protocols"></a> Segment Protocols
+## Segment Protocols
 
 The integration to [Segment Protocols](https://segment.com/docs/protocols) allows for your Tracking Plan to be published into Segment Protocols whenever branches are merged in your workspace or with a push of a button.
 
@@ -90,7 +90,7 @@ Avo will not override any events that are only defined in Protocols, or events t
   style={{ margin: '32px 0 -32px 0' }}
 />
 
-## <a name="mixpanel-lexicon"></a> Mixpanel Lexicon
+## Mixpanel Lexicon
 
 The integration to [Mixpanel Lexicon](https://mixpanel.com/data-governance/) allows for your Tracking Plan to be published into Mixpanel Lexicon whenever a branch is merged in your workspace or with a push of a button.
 
@@ -116,7 +116,7 @@ Avo will not impact any events that are only defined in Lexicon, or events that 
   style={{ margin: '32px 0 -32px 0' }}
 />
 
-## <a name="amplitude-govern"></a> Amplitude Govern
+## Amplitude Govern
 
 The integration to [Ampltitude Govern](https://amplitude.com/govern) allows for your Tracking Plan to be published into Amplitude Govern whenever a branch has been merged. You can also manually trigger a publish by clicking the "Publish to Govern" button on the integration screen or download a CSV file on the Amplitdue Govern format. The events to be published can be filtered by Sources, Destinations and Tags.
 
@@ -165,7 +165,7 @@ We've exceeded the number of Govern requests we can make per hour for these API 
   style={{ margin: '32px 0 -32px 0' }}
 />
 
-## <a name="webhook"></a> Webhook
+## Webhook
 
 The Webhook integration is a way to get updated Tracking Plan delivered to an endpoint of your choice when a branch is merge, or when the publish button is clicked in the integration interface.
 


### PR DESCRIPTION
This redundant code is ignored in the title but parsed in the title id (which can be # linked to) as `a-name-[name]-[name]` which isn't pretty. Doing a search for `<a name="` resulted in tens of more cases like these in other files. Is this supposed to be there?