### PR TITLE
Remove Vercel functions config to get an optimised build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,4 @@
 {
-  "functions": {
-    "pages/api/**": {
-      "memory": 3008
-    }
-  },
   "redirects": [
     {
       "source": "/quickstart/",


### PR DESCRIPTION
I noticed this error on the Vercel build:

<img width="704" alt="Screenshot 2021-03-10 at 09 39 24" src="https://user-images.githubusercontent.com/4923531/110609086-c5da0d00-8184-11eb-88b5-1b70d1a02786.png">

It links to this page: https://github.com/vercel/vercel/blob/master/errors/next-functions-config-optimized-lambdas.md
The "fix" is to remove the functions config to get an optimized build.