### PR TITLE
Allow layout content to shrink to fix overflow

### DIFF
--- a/components/Layout.module.scss
+++ b/components/Layout.module.scss
@@ -2,7 +2,7 @@
 
 .grid {
   display: grid;
-  grid-template-columns: 300px 1fr;
+  grid-template-columns: 300px minmax(0, 1fr);
   grid-template-rows: auto 1fr;
   gap: 10px 15px;
   grid-template-areas:


### PR DESCRIPTION
Some pages were super wide because the layout grid wasn't limiting the width of the children. The `<pre>` element seems to be notorious for doing that. I've fixed it by allowing the content column to shrink.

Before:
![Screenshot 2021-05-10 at 09 47 46](https://user-images.githubusercontent.com/4923531/117640994-2c73ab00-b175-11eb-964f-0a48dd18f7c4.png)

After:
![Screenshot 2021-05-10 at 09 48 02](https://user-images.githubusercontent.com/4923531/117640998-30073200-b175-11eb-8144-fd900aff1cee.png)
