### PR TITLE
Initialize Docsearch when script tag has loaded

### DIFF
--- a/components/DocSearch.module.scss
+++ b/components/DocSearch.module.scss
@@ -32,4 +32,9 @@
   }
 
   border-bottom: 2px solid transparent;
+  transition: opacity 300ms;
+}
+
+.searchInput:disabled {
+  opacity: 0.5;
 }

--- a/components/DocSearch.tsx
+++ b/components/DocSearch.tsx
@@ -27,7 +27,7 @@ const DocSearch: FunctionComponent = () => {
   const [searchHits, setSearchHits] = useState<SearchHit[]>([]);
   const [searchStatus, setSearchStatus] = useState(Status.NotFocused);
 
-  const [isLoading, setLoading] = useState(true);
+  const [isLoading, setLoading] = useState(false);
 
   const initializeDocSearch = () => {
     let searchHits: SearchHit[] = [];

--- a/components/DocSearch.tsx
+++ b/components/DocSearch.tsx
@@ -74,10 +74,12 @@ const DocSearch: FunctionComponent = () => {
       const scriptTag = document.querySelector('#load-docsearch-script');
       if (scriptTag) {
         scriptTag.addEventListener('load', function () {
+          // eslint-disable-next-line no-console
           console.info('Docsearch loaded, initializing...');
           initializeDocSearch();
         });
       } else {
+        // eslint-disable-next-line no-console
         console.error(
           'Could not load Docsearch, script tag with the id #load-docsearch-script not found',
         );

--- a/components/DocSearch.tsx
+++ b/components/DocSearch.tsx
@@ -71,6 +71,7 @@ const DocSearch: FunctionComponent = () => {
       console.info(
         'Still waiting for Docsearch to load, setting up onload listener...',
       );
+      setLoading(true);
       const scriptTag = document.querySelector('#load-docsearch-script');
       if (scriptTag) {
         scriptTag.addEventListener('load', function () {

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -36,6 +36,7 @@ class MyDocument extends Document {
           </noscript>
           {/* End Google Tag Manager (noscript) */}
           <script
+            id="load-docsearch-script"
             type="text/javascript"
             src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
           ></script>


### PR DESCRIPTION
If the Docsearch script tag isn't loaded when the app mounts, we set up a listener which initializes docsearch when the script tag has loaded.

https://user-images.githubusercontent.com/3513968/142402383-167064b0-f90f-4d08-acd3-3b28ebc569f6.mp4

