### PR TITLE
Add pre-commit linter

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn spellcheck && yarn lint && yarn lint-mdx

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "fix-spelling": "yarn mdspell 'pages/*.mdx' 'pages/*/*.mdx' 'pages/*/*/*.mdx' 'pages/*/*/*/*.mdx' --en-us -x -n",
     "lint": "eslint '*/**/*.{js,ts,tsx}' && tsc --noEmit",
     "lint-mdx": "ts-node -O '{ \"module\": \"commonjs\" }' --files util/mdxLint/index.ts",
-    "generate-sitemap": "ts-node -O '{ \"module\": \"commonjs\" }' --files util/generateSitemap.ts"
+    "generate-sitemap": "ts-node -O '{ \"module\": \"commonjs\" }' --files util/generateSitemap.ts",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
@@ -69,6 +70,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "glob": "^8.0.3",
     "globby": "^11.1.0",
+    "husky": "^7.0.0",
     "parse-es6-imports": "^1.0.1",
     "prettier": "^2.6.2",
     "remark": "^12.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3337,6 +3337,11 @@ hunspell-spellchecker@^1.0.2:
   resolved "https://registry.yarnpkg.com/hunspell-spellchecker/-/hunspell-spellchecker-1.0.2.tgz#a10b0bd2fa00a65ab62a4c6b734ce496d318910e"
   integrity sha1-oQsL0voAplq2Kkxrc0zkltMYkQ4=
 
+husky@^7.0.0:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
+  integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
Adds a pre-commit for the linters and spellcheck so you don't have to wait for the GitHub build to fail when you forget it.