### PR TITLE
Upgrade Node to version 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        #node-version: [8.x, 10.x, 12.x]
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -12,8 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        #node-version: [8.x, 10.x, 12.x]
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/lodash.throttle": "^4.1.7",
     "@types/marked": "^2.0.0",
     "@types/mdx-js__react": "^1.5.5",
-    "@types/node": "^14.18.20",
+    "@types/node": "16.11.38",
     "@types/prettier": "^2.6.3",
     "@types/puppeteer": "^5.4.6",
     "@types/react": "^17.0.45",

--- a/pages/implementation/avo-in-the-ci.mdx
+++ b/pages/implementation/avo-in-the-ci.mdx
@@ -74,7 +74,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/yarn.lock
+++ b/yarn.lock
@@ -890,10 +890,15 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/node@*", "@types/node@>= 8", "@types/node@^14.18.20":
+"@types/node@*", "@types/node@>= 8":
   version "14.18.20"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.20.tgz#268f028b36eaf51181c3300252f605488c4f0650"
   integrity sha512-Q8KKwm9YqEmUBRsqJ2GWJDtXltBDxTdC4m5vTdXBolu2PeQh8LX+f6BTwU+OuXPu37fLxoN6gidqBmnky36FXA==
+
+"@types/node@16.11.38":
+  version "16.11.38"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.38.tgz#be0edd097b23eace6c471c525a74b3f98803017f"
+  integrity sha512-hjO/0K140An3GWDw2HJfq7gko3wWeznbjXgg+rzPdVzhe198hp4x2i1dgveAOEiFKd8sOilAxzoSJiVv5P/CUg==
 
 "@types/parse5@^5.0.0":
   version "5.0.3"


### PR DESCRIPTION
Updates our builds and types to Node 16 as well as the Avo cli code example