### PR TITLE
Update Govern 404 docs

### DIFF
--- a/pages/workspace/tracking-plan/publishing.mdx
+++ b/pages/workspace/tracking-plan/publishing.mdx
@@ -363,7 +363,10 @@ Here's how events, properties and categories are mapped from Avo to Govern:
 
 The following errors might occur when publishing your tracking to Govern. When publishing errors occur the error message in the Avo UI will contain which items could not be updated along with the error codes.
 
-- **404 Not Found**: We tried to update an event that doesn't exist in your Amplitude Govern Schema. If this error occurs for all of the events you are attempting to publish it might indicate that your Amplitude Govern Schema has not been initialized. Learn more about initializing your Amplitude Govern Schema in [the Amplitude Govern docs](https://help.amplitude.com/hc/en-us/articles/360047579451-Initialize-and-manage-the-Schema).
+- **404 Not Found**: This error can be thrown in few scenarios:
+  - We tried to update an event that doesn't exist in your Amplitude Govern Schema
+  - If this error only occurs for events and properties Amplitude hasn't seen yet, it might indicate that the schema in Amplitude Govern hasn't been initialized, or that you don't have access to the "Plan data" functionality in Amplitude Govern
+  - If this error occurs for all of the events you are attempting to publish it might indicate that your Amplitude Govern Schema has not been initialized. Learn more about initializing your Amplitude Govern Schema in [the Amplitude Govern docs](https://help.amplitude.com/hc/en-us/articles/360047579451-Initialize-and-manage-the-Schema).
   After you Govern Schema is initialized usually the API continues to return occasional 404 errors for a few more hours. If your Govern Schema has been initialized more than 6 hours ago and the error persists, please contact support.
 
 - **408 Timeout**: The publishing operation took too long. This can happen when publishing large tracking plans for the first time. Click publish again to resume the publish, it will continue from where it left off.


### PR DESCRIPTION
Cover the case where non-existing events and properties can't be created because of lack of access to the "Plan data" functionality in Govern