### PR TITLE
Fix links in workflow docs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -237,6 +237,12 @@ IdP-initiated
 v3.2.0
 coroutines
 KotlinCoroutines
+devs-101
+integrations#slack
+implementation-status#inspector-implementation-status
+avo-functions-overview#whats-happening-inside-the-avo-functions
+avo-in-the-ci
+implementation-status#avo-functions-implementation-status
  - pages/data-design/defining-descriptive-events-and-properties.mdx
 facebook
  - pages/explore-tracking-plan/issue-types-in-inspector.mdx

--- a/components/PageLink.tsx
+++ b/components/PageLink.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 
 import styles from './PageLink.module.scss';
 import Icon from './Icon';
-import Link from 'next/link';
+import Link from '../components/Link';
 
 export class CallToAction {
   constructor(readonly path: string) {}

--- a/pages/workflow/implement.mdx
+++ b/pages/workflow/implement.mdx
@@ -35,7 +35,7 @@ When using the implementation instructions from Avo, we recommend checking out o
     description="How to read the implementation diff"
     callToAction={
       new CallToAction(
-        'https://www.avo.app/docs/implementation/read-implementation-diff',
+        '/implementation/read-implementation-diff',
       )
     }
   />
@@ -53,7 +53,7 @@ Learn more about Avo’s developer tools in Avo 101 for developers:
     title="Avo 101 for developers"
     description="Learn about Avo’s developer tools"
     callToAction={
-      new CallToAction('https://www.avo.app/docs/implementation/devs-101')
+      new CallToAction('/implementation/devs-101')
     }
   />
 </div>
@@ -73,7 +73,7 @@ If Avo Functions haven’t been set up in your project yet, learn how to set the
     description="Start using Avo Functions"
     callToAction={
       new CallToAction(
-        'https://www.avo.app/docs/implementation/start-using-avo-functions',
+        '/implementation/start-using-avo-functions',
       )
     }
   />
@@ -87,7 +87,7 @@ If Avo Functions haven’t been set up in your project yet, learn how to set the
     title="5. Validate implementation"
     description="Learn how to validate implementation"
     callToAction={
-      new CallToAction('https://www.avo.app/docs/workflow/validate')
+      new CallToAction('/workflow/validate')
     }
   />
 </div>

--- a/pages/workflow/implement.mdx
+++ b/pages/workflow/implement.mdx
@@ -13,7 +13,6 @@ import DevIcon from '../../images/svg/dev.svg';
 import { FunctionComponent } from 'react';
 import Zoom from 'react-medium-image-zoom';
 
-
 Avo provides a set of developer tools to make it faster and less error prone to implement tracking code. <Link passHref href="/implementation/devs-101#avo-functions-type-safe-analytics-wrappers"><a>Avo Functions</a></Link>, our type safe analytics wrappers, are one of those tools. Using Avo’s developer tools is optional, but something we highly recommend.
 
 In this guide we’ll cover how to implement analytics events with and without using Avo’s developer tools.
@@ -23,66 +22,72 @@ In this guide we’ll cover how to implement analytics events with and without u
 You can continue implementing your tracking code like you are used to using analytics SDKs from analytics platforms (like Mixpanel, PostHog or Amplitude), SDKs from CDPs (like Rudderstack, Segment or mParticle), or using internal built SDKs or APIs.
 
 A typical implementation workflow looks like this:
+
 1. Open a git branch to implement your analytics tracking changes on
 2. Follow the implementation instructions provided on the branch review screen in Avo for what needs to be done
 
 When using the implementation instructions from Avo, we recommend checking out our guide on how to read the implementation instructions:
 
- <div className={styles.row}>
-          <PageLink
-            image={AnalyticsManagerIcon}
-            title="Implementation diff"
-            description="How to read the implementation diff"
-            callToAction={
-              new CallToAction('https://www.avo.app/docs/implementation/read-implementation-diff')
-            }
-          />
-  </div>
+<div className={styles.row}>
+  <PageLink
+    image={AnalyticsManagerIcon}
+    title="Implementation diff"
+    description="How to read the implementation diff"
+    callToAction={
+      new CallToAction(
+        'https://www.avo.app/docs/implementation/read-implementation-diff',
+      )
+    }
+  />
+</div>
 
 # Implementing with Avo Functions
 
-Avo Functions are type safe analytics wrappers that are code generated based on your tracking plan. Designed to speed up the tracking code implementation, while also making it more reliable with type-safety. 
+Avo Functions are type safe analytics wrappers that are code generated based on your tracking plan. Designed to speed up the tracking code implementation, while also making it more reliable with type-safety.
 
 Learn more about Avo’s developer tools in Avo 101 for developers:
 
- <div className={styles.row}>
-          <PageLink
-            image={AnalyticsManagerIcon}
-            title="Avo 101 for developers"
-            description="Learn about Avo’s developer tools"
-            callToAction={
-              new CallToAction('https://www.avo.app/docs/implementation/devs-101')
-            }
-          />
-  </div>
+<div className={styles.row}>
+  <PageLink
+    image={AnalyticsManagerIcon}
+    title="Avo 101 for developers"
+    description="Learn about Avo’s developer tools"
+    callToAction={
+      new CallToAction('https://www.avo.app/docs/implementation/devs-101')
+    }
+  />
+</div>
 
 For teams that are using Avo Functions to implement their tracking code, the typical implementation workflow looks like this:
+
 1. Open a git branch to implement your analytics tracking changes on.
-2. Use the <Link passHref href="/implementation/cli"><a>Avo CLI</a></Link> to pull the updated code from the branch you are implementing. You can find the Avo CLI command for each source in the top right corner of the branch review screen under “Branch Implementation”. From there you can also access documentation for all the events that need to be implemented 
+2. Use the <Link passHref href="/implementation/cli"><a>Avo CLI</a></Link> to pull the updated code from the branch you are implementing. You can find the Avo CLI command for each source in the top right corner of the branch review screen under “Branch Implementation”. From there you can also access documentation for all the events that need to be implemented
 3. Use the Avo Functions provided in the generated code to implement your events in your source code. [The Functions tab in your workspace](https://www.avo.app/schemas/fwtXqAc0fCLy7b7oGW40/implement/fs/WUFObVFR4PVbZGtT1hQ5) provides documentation and code snippets for each event
 
 If Avo Functions haven’t been set up in your project yet, learn how to set them up in our Avo Functions quickstart guide:
 
- <div className={styles.row}>
-          <PageLink
-            image={DevIcon}
-            title="Quickstart: Avo Functions"
-            description="Start using Avo Functions"
-            callToAction={
-              new CallToAction('https://www.avo.app/docs/implementation/start-using-avo-functions')
-            }
-          />
-  </div>
+<div className={styles.row}>
+  <PageLink
+    image={DevIcon}
+    title="Quickstart: Avo Functions"
+    description="Start using Avo Functions"
+    callToAction={
+      new CallToAction(
+        'https://www.avo.app/docs/implementation/start-using-avo-functions',
+      )
+    }
+  />
+</div>
 
 ## What’s next?
 
- <div className={styles.row}>
-          <PageLink
-            image={AnalyticsManagerIcon}
-            title="5. Validate implementation"
-            description="Learn how to validate implementation"
-            callToAction={
-              new CallToAction("https://www.avo.app/docs/workflow/validate")
-            }
-          />
-  </div>
+<div className={styles.row}>
+  <PageLink
+    image={AnalyticsManagerIcon}
+    title="5. Validate implementation"
+    description="Learn how to validate implementation"
+    callToAction={
+      new CallToAction('https://www.avo.app/docs/workflow/validate')
+    }
+  />
+</div>

--- a/pages/workflow/implement.mdx
+++ b/pages/workflow/implement.mdx
@@ -76,13 +76,13 @@ If Avo Functions haven’t been set up in your project yet, learn how to set the
 
 ## What’s next?
 
- > <div className={styles.row}>
+ <div className={styles.row}>
           <PageLink
             image={AnalyticsManagerIcon}
             title="5. Validate implementation"
             description="Learn how to validate implementation"
             callToAction={
-              new CallToAction("/workflow/validate")
+              new CallToAction("https://www.avo.app/docs/workflow/validate")
             }
           />
   </div>

--- a/pages/workflow/merge-publish.mdx
+++ b/pages/workflow/merge-publish.mdx
@@ -10,7 +10,6 @@ import PageLink, { CallToAction } from '../../components/PageLink';
 import AnalyticsManagerIcon from '../../images/svg/analyticsmanager.svg';
 import DevIcon from '../../images/svg/dev.svg';
 
-
 # Merge Avo branch
 
 When you have finished the tracking implementation and validated it, you are ready to merge your Avo branch.
@@ -20,14 +19,14 @@ We recommend merging your Avo branch after all related git branches containing t
 You can learn more about using Avo branches in a git workflow at scale here:
 
 <div className={styles.row}>
-          <PageLink
-            image={DevIcon}
-            title="Avo branches at a large scale"
-            description="​​Using Avo in large development teams with parallel workflows"
-            callToAction={
-              new CallToAction('https://www.avo.app/docs/implementation/avo-and-git')
-            }
-          />
+  <PageLink
+    image={DevIcon}
+    title="Avo branches at a large scale"
+    description="​​Using Avo in large development teams with parallel workflows"
+    callToAction={
+      new CallToAction('https://www.avo.app/docs/implementation/avo-and-git')
+    }
+  />
 </div>
 
 # Publish tracking plan updates to schema registries
@@ -39,20 +38,18 @@ You can configure Avo to auto-publish your tracking changes to your downstream s
 You can learn more about how to push or pull to keep schema registries in sync, including with publishing, here:
 
 <div className={styles.row}>
-          <PageLink
-            image={AnalyticsManagerIcon}
-            title="Publishing"
-            description="How to publish your tracking updates"
-            callToAction={
-              new CallToAction('https://www.avo.app/docs/workspace/tracking-plan/publishing')
-            }
-          />
+  <PageLink
+    image={AnalyticsManagerIcon}
+    title="Publishing"
+    description="How to publish your tracking updates"
+    callToAction={
+      new CallToAction(
+        'https://www.avo.app/docs/workspace/tracking-plan/publishing',
+      )
+    }
+  />
 </div>
 
 ## You just completed the final step of the Avo workflow!
 
 Congrats, by completing this step you’ve completed the Avo workflow for an analytics release! 🎉
-
-
-
-

--- a/pages/workflow/merge-publish.mdx
+++ b/pages/workflow/merge-publish.mdx
@@ -24,7 +24,7 @@ You can learn more about using Avo branches in a git workflow at scale here:
     title="Avo branches at a large scale"
     description="​​Using Avo in large development teams with parallel workflows"
     callToAction={
-      new CallToAction('https://www.avo.app/docs/implementation/avo-and-git')
+      new CallToAction('/implementation/avo-and-git')
     }
   />
 </div>
@@ -44,7 +44,7 @@ You can learn more about how to push or pull to keep schema registries in sync, 
     description="How to publish your tracking updates"
     callToAction={
       new CallToAction(
-        'https://www.avo.app/docs/workspace/tracking-plan/publishing',
+        '/workspace/tracking-plan/publishing',
       )
     }
   />

--- a/pages/workflow/overview.mdx
+++ b/pages/workflow/overview.mdx
@@ -54,6 +54,6 @@ For your analytics release cycle (and Avo branches), we recommend following the 
     image={AnalyticsManagerIcon}
     title="1. Plan analytics update in Avo branch"
     description="Learn how to plan an analytic update in Avo branch"
-    callToAction={new CallToAction('https://www.avo.app/docs/workflow/plan')}
+    callToAction={new CallToAction('/workflow/plan')}
   />
 </div>

--- a/pages/workflow/overview.mdx
+++ b/pages/workflow/overview.mdx
@@ -26,9 +26,9 @@ The Avo workflow for analytics releases is inspired by the general best practice
 
 <center>
   <img
-        width="100%"
-        src={require('../../images/workflow/overview/avo-workflow.png')}
-        alt="The Avo Workflow: Plan, review, implement, validate and publish your tracking changes"
+    width="100%"
+    src={require('../../images/workflow/overview/avo-workflow.png')}
+    alt="The Avo Workflow: Plan, review, implement, validate and publish your tracking changes"
   />
 </center>
 
@@ -42,19 +42,18 @@ If you don’t have an upcoming analytics release, you can start kicking the tir
 
 Your main branch in Avo should represent what is currently being tracked in production. As soon as event implementation is done, you merge your Avo branch into your Avo main branch.
 
-For your analytics release cycle (and Avo branches), we recommend following the same best practices as generally apply to the software development lifecycle (and git branches): 
-- Release Early, Release Often. This will streamline collaboration across teams, platforms and products of your new single-source-of-truth tracking plan. 
-- In practice, this means: Keep Avo branches small and release often, rather than designing a large set of changes that should be implemented over multiple product releases. 
+For your analytics release cycle (and Avo branches), we recommend following the same best practices as generally apply to the software development lifecycle (and git branches):
+
+- Release Early, Release Often. This will streamline collaboration across teams, platforms and products of your new single-source-of-truth tracking plan.
+- In practice, this means: Keep Avo branches small and release often, rather than designing a large set of changes that should be implemented over multiple product releases.
 
 ## Ready to get going?
 
- > <div className={styles.row}>
-          <PageLink
-            image={AnalyticsManagerIcon}
-            title="1. Plan analytics update in Avo branch"
-            description="Learn how to plan an analytic update in Avo branch"
-            callToAction={
-              new CallToAction("/workflow/plan")
-            }
-          />
-  </div>
+<div className={styles.row}>
+  <PageLink
+    image={AnalyticsManagerIcon}
+    title="1. Plan analytics update in Avo branch"
+    description="Learn how to plan an analytic update in Avo branch"
+    callToAction={new CallToAction('https://www.avo.app/docs/workflow/plan')}
+  />
+</div>

--- a/pages/workflow/plan.mdx
+++ b/pages/workflow/plan.mdx
@@ -104,6 +104,6 @@ _Example: Event definition_
     image={AnalyticsManagerIcon}
     title="2. Review suggestions in Avo"
     description="Learn how to review suggestions in Avo"
-    callToAction={new CallToAction('https://www.avo.app/docs/workflow/review')}
+    callToAction={new CallToAction('/workflow/review')}
   />
 </div>

--- a/pages/workflow/plan.mdx
+++ b/pages/workflow/plan.mdx
@@ -19,22 +19,25 @@ _Role: Product or Data (This initiative is usually led by a product oriented per
 The hardest part in the whole analytics release process is usually to decide what events and properties you need, to be able to measure the success of the product change. There are many paths to a decision, but no matter which one you take, we recommend doing it as early as possible in the development process.
 
 We always recommend starting by formulating the metrics you hope to move with your change. Our favorite way to do this is what we like to call a <Link passHref href="/blog/tracking-the-right-product-metrics"><a>“Purpose Meeting”</a></Link>. The outcomes of that meeting are:
+
 1. Goals – what does success look like?
 2. Metrics – how will we measure how successful we are?
 3. Data – what analytics events do we need for our success metrics?
 
 The result of the purpose meeting is usually a draft of events that someone takes forward to the next step.
 
- <div className={styles.row}>
-          <PageLink
-            image={AnalyticsManagerIcon}
-            title="Blog Post: Purpose Meeting"
-            description="Learn about the Purpose Meeting"
-            callToAction={
-              new CallToAction('https://www.avo.app/blog/tracking-the-right-product-metrics')
-            }
-          />
-  </div>
+<div className={styles.row}>
+  <PageLink
+    image={AnalyticsManagerIcon}
+    title="Blog Post: Purpose Meeting"
+    description="Learn about the Purpose Meeting"
+    callToAction={
+      new CallToAction(
+        'https://www.avo.app/blog/tracking-the-right-product-metrics',
+      )
+    }
+  />
+</div>
 
 ## 1.2 Create a branch in Avo
 
@@ -48,13 +51,13 @@ To create a new branch, first make sure you are on the main branch. You can see 
 
 <center>
   <img
-        width="70%"
-        src={require('../../images/workflow/1.plan/create-new-branch.png')}
-        alt="create a new branch from the navigation bar"
+    width="70%"
+    src={require('../../images/workflow/1.plan/create-new-branch.png')}
+    alt="create a new branch from the navigation bar"
   />
 </center>
 
-> 💡 Name your branch in a way that helps your team mates know what the branch is about. We recommend the branch name references the product update or feature it’s connected to in some way. Some teams also like including a reference to the team involved in the change and/or a ticket number from their task management system. 
+> 💡 Name your branch in a way that helps your team mates know what the branch is about. We recommend the branch name references the product update or feature it’s connected to in some way. Some teams also like including a reference to the team involved in the change and/or a ticket number from their task management system.
 
 <video
   controls
@@ -85,25 +88,22 @@ There are a few things to keep in mind when doing so:
 - Try to apply <Link passHref href="/audit/rules#property-rules"><a>property rules</a></Link> on your properties if possible. This is especially useful when you have a string property that has a finite number of possible values.
 
 <center>
-    <img
-          width="70%"
-          src={require('../../images/workflow/1.plan/event.png')}
-          alt="even definition"
-    />
+  <img
+    width="70%"
+    src={require('../../images/workflow/1.plan/event.png')}
+    alt="even definition"
+  />
 </center>
 
 _Example: Event definition_
 
-
 ## What’s next?
 
-  <div className={styles.row}>
-          <PageLink
-            image={AnalyticsManagerIcon}
-            title="2. Review suggestions in Avo"
-            description="Learn how to review suggestions in Avo"
-            callToAction={
-              new CallToAction("https://www.avo.app/docs/workflow/review")
-            }
-          />
-  </div>
+<div className={styles.row}>
+  <PageLink
+    image={AnalyticsManagerIcon}
+    title="2. Review suggestions in Avo"
+    description="Learn how to review suggestions in Avo"
+    callToAction={new CallToAction('https://www.avo.app/docs/workflow/review')}
+  />
+</div>

--- a/pages/workflow/plan.mdx
+++ b/pages/workflow/plan.mdx
@@ -97,13 +97,13 @@ _Example: Event definition_
 
 ## What’s next?
 
-  > <div className={styles.row}>
+  <div className={styles.row}>
           <PageLink
             image={AnalyticsManagerIcon}
             title="2. Review suggestions in Avo"
             description="Learn how to review suggestions in Avo"
             callToAction={
-              new CallToAction("/workflow/review")
+              new CallToAction("https://www.avo.app/docs/workflow/review")
             }
           />
   </div>

--- a/pages/workflow/request-implementation.mdx
+++ b/pages/workflow/request-implementation.mdx
@@ -48,13 +48,13 @@ We recommend checking out our guide on how to read the implementation instructio
 
 ## What’s next?
 
- > <div className={styles.row}>
+ <div className={styles.row}>
           <PageLink
             image={AnalyticsManagerIcon}
             title="4. Implement analytics events"
             description="Learn how to implement analytics event"
             callToAction={
-              new CallToAction("/workflow/implement")
+              new CallToAction("https://www.avo.app/docs/workflow/implement")
             }
           />
   </div>

--- a/pages/workflow/request-implementation.mdx
+++ b/pages/workflow/request-implementation.mdx
@@ -3,6 +3,7 @@ layout: 'guide'
 title: '3. Request implementation'
 abstract: ''
 ---
+
 import Link from '../../components/Link';
 import styles from '../index.module.scss';
 import PageLink, { CallToAction } from '../../components/PageLink';
@@ -17,9 +18,9 @@ If your branch includes changes on at least one source then the implementation i
 
 <center>
   <img
-        width="100%"
-        src={require('../../images/workflow/3.request-implementation/diff-panel.png')}
-        alt="The Avo Workflow: Plan, review, implement, validate and publish your tracking changes"
+    width="100%"
+    src={require('../../images/workflow/3.request-implementation/diff-panel.png')}
+    alt="The Avo Workflow: Plan, review, implement, validate and publish your tracking changes"
   />
 </center>
 
@@ -27,35 +28,36 @@ You can copy the instructions and pass them to developers for implementation in 
 
 <center>
   <img
-        width="100%"
-        src={require('../../images/workflow/3.request-implementation/diff-implementation.png')}
-        alt="The Avo Workflow: Plan, review, implement, validate and publish your tracking changes"
+    width="100%"
+    src={require('../../images/workflow/3.request-implementation/diff-implementation.png')}
+    alt="The Avo Workflow: Plan, review, implement, validate and publish your tracking changes"
   />
 </center>
 
 We recommend checking out our guide on how to read the implementation instructions:
 
- <div className={styles.row}>
-          <PageLink
-            image={DevIcon}
-            title="Implementation diff"
-            description="How to read the implementation diff"
-            callToAction={
-              new CallToAction('https://www.avo.app/docs/implementation/read-implementation-diff')
-            }
-          />
-  </div>
+<div className={styles.row}>
+  <PageLink
+    image={DevIcon}
+    title="Implementation diff"
+    description="How to read the implementation diff"
+    callToAction={
+      new CallToAction(
+        'https://www.avo.app/docs/implementation/read-implementation-diff',
+      )
+    }
+  />
+</div>
 
 ## What’s next?
 
- <div className={styles.row}>
-          <PageLink
-            image={AnalyticsManagerIcon}
-            title="4. Implement analytics events"
-            description="Learn how to implement analytics event"
-            callToAction={
-              new CallToAction("https://www.avo.app/docs/workflow/implement")
-            }
-          />
-  </div>
-
+<div className={styles.row}>
+  <PageLink
+    image={AnalyticsManagerIcon}
+    title="4. Implement analytics events"
+    description="Learn how to implement analytics event"
+    callToAction={
+      new CallToAction('https://www.avo.app/docs/workflow/implement')
+    }
+  />
+</div>

--- a/pages/workflow/request-implementation.mdx
+++ b/pages/workflow/request-implementation.mdx
@@ -43,7 +43,7 @@ We recommend checking out our guide on how to read the implementation instructio
     description="How to read the implementation diff"
     callToAction={
       new CallToAction(
-        'https://www.avo.app/docs/implementation/read-implementation-diff',
+        '/implementation/read-implementation-diff',
       )
     }
   />
@@ -57,7 +57,7 @@ We recommend checking out our guide on how to read the implementation instructio
     title="4. Implement analytics events"
     description="Learn how to implement analytics event"
     callToAction={
-      new CallToAction('https://www.avo.app/docs/workflow/implement')
+      new CallToAction('/workflow/implement')
     }
   />
 </div>

--- a/pages/workflow/review.mdx
+++ b/pages/workflow/review.mdx
@@ -68,7 +68,7 @@ We also recommend you set up the Slack workflow integration for your Avo workspa
     title="Slack notifications"
     description="Learn how to enable Slack notifications in your Avo Workspace"
     callToAction={
-      new CallToAction('https://www.avo.app/docs/workspace/integrations#slack')
+      new CallToAction('/workspace/integrations#slack')
     }
   />
 </div>
@@ -81,7 +81,7 @@ Additionally, with approval workflows you can configure how many approvals are r
     title="Approval workflows"
     description="Increase the quality of your tracking plan with protected main branch and branch approvals"
     callToAction={
-      new CallToAction('https://www.avo.app/docs/workspace/approval-workflows')
+      new CallToAction('/workspace/approval-workflows')
     }
   />
 </div>
@@ -141,7 +141,7 @@ When you are done with the review, if your workspace has <Link passHref href="/w
     description="Learn how to request implementation"
     callToAction={
       new CallToAction(
-        'https://www.avo.app/docs/workflow/request-implementation',
+        '/workflow/request-implementation',
       )
     }
   />

--- a/pages/workflow/review.mdx
+++ b/pages/workflow/review.mdx
@@ -16,11 +16,11 @@ import { FunctionComponent } from 'react';
 
 _Role: Product, Data, Engineering. See more below _
 
-
 Once you have drafted changes to your tracking plan we recommend asking your teammates to review your suggested changes.
 
 **Who should be asked for a review?**
 We typically see three types of reviewers:
+
 - **Product team:** Someone who is responsible for the related feature or user flow that verifies that the metrics mapped out on the branch suffice for their data needs
 - **Data team:** Someone who validates that the changes made are according to the data standard of your company
 - **Engineering team:** The folks who will implement the suggested changes. If the changes made affect multiple sources (e.g. iOS, Android, Web, backend) we recommend to get reviews from the teams working on each source
@@ -29,19 +29,21 @@ We typically see three types of reviewers:
 The first step is to mark the branch as “Ready for review”. This is done at the bottom of the review screen as seen on the screenshot below.
 
 <center>
-    <img
-        width="60%"
-        src={require('../../images/workflow/2.review/ready-for-review.png')}
-        alt="even definition"
-    />
+  <img
+    width="60%"
+    src={require('../../images/workflow/2.review/ready-for-review.png')}
+    alt="even definition"
+  />
 </center>
 
-_Example: Changes ready for review_ 
+_Example: Changes ready for review_
 
 > Note that detailed branch statuses like “Draft”, “Ready for Review”, “Request changes” and “Approved” are only available on our paid plans. If you’re currently on the Free plan you can start a free trial today to try it out.
 
 There are couple ways to share a review request:
+
 - Add the reviewers as [branch collaborators](https://www.avo.app/blog/introducing-branch-collaborators): Go to the branch review screen of your branch and add your reviewers as collaborators. A collaborator will receive an email when added to your branch, when discussions are started, when the branch status is updated and when the branch is merged or closed.
+
   <video
     controls
     loop
@@ -58,46 +60,46 @@ There are couple ways to share a review request:
 
 > 💡 Follow the same process for requesting branch reviews on Avo as you would for other types of internal requests. For example if your team mostly works in Asana or Jira, create an Asana task or Jira ticket with a link to the branch review screen.
 
-We also recommend you set up the Slack workflow integration for your Avo workspace. The Slack workflow integration will post all branch updates and comments to a Slack channel of your choice. 
+We also recommend you set up the Slack workflow integration for your Avo workspace. The Slack workflow integration will post all branch updates and comments to a Slack channel of your choice.
 
- <div className={styles.row}>
-          <PageLink
-            image={DevIcon}
-            title="Slack notifications"
-            description="Learn how to enable Slack notifications in your Avo Workspace"
-            callToAction={
-              new CallToAction('https://www.avo.app/docs/workspace/integrations#slack')
-            }
-          />
-  </div>
+<div className={styles.row}>
+  <PageLink
+    image={DevIcon}
+    title="Slack notifications"
+    description="Learn how to enable Slack notifications in your Avo Workspace"
+    callToAction={
+      new CallToAction('https://www.avo.app/docs/workspace/integrations#slack')
+    }
+  />
+</div>
 
 Additionally, with approval workflows you can configure how many approvals are required, and who can approve, before the branch can be merged.
 
- <div className={styles.row}>
-          <PageLink
-            image={AnalyticsManagerIcon}
-            title="Approval workflows"
-            description="Increase the quality of your tracking plan with protected main branch and branch approvals"
-            callToAction={
-              new CallToAction('https://www.avo.app/docs/workspace/approval-workflows')
-            }
-          />
-  </div>
+<div className={styles.row}>
+  <PageLink
+    image={AnalyticsManagerIcon}
+    title="Approval workflows"
+    description="Increase the quality of your tracking plan with protected main branch and branch approvals"
+    callToAction={
+      new CallToAction('https://www.avo.app/docs/workspace/approval-workflows')
+    }
+  />
+</div>
 
 ## Submit a review
 
-The role of the reviewer(s) is to make sure that the suggested changes fit your data needs, are according to the existing standards and naming conventions, and are feasible for implementation. 
+The role of the reviewer(s) is to make sure that the suggested changes fit your data needs, are according to the existing standards and naming conventions, and are feasible for implementation.
 
-The branch review screen in Avo summarizes the changes that have been suggested on the branch. 
+The branch review screen in Avo summarizes the changes that have been suggested on the branch.
 
 On the review screen, you can comment on every item that has been introduced or changed on your branch, ask questions and suggest changes.
 
 <center>
-    <img
-          width="100%"
-          src={require('../../images/workflow/2.review/add-comments.png')}
-          alt="Adding comment"
-    />
+  <img
+    width="100%"
+    src={require('../../images/workflow/2.review/add-comments.png')}
+    alt="Adding comment"
+  />
 </center>
 
 _Example: Adding comment to the changes_
@@ -119,11 +121,11 @@ _Example: Adding comment directly to an item_
 You can add a comment at the bottom of the review to discuss the overall branch, give thumbs up for approval, or request changes.
 
 <center>
-    <img
-          width="100%"
-          src={require('../../images/workflow/2.review/comment-whole-branch.png')}
-          alt="Adding comment"
-    />
+  <img
+    width="100%"
+    src={require('../../images/workflow/2.review/comment-whole-branch.png')}
+    alt="Adding comment"
+  />
 </center>
 
 _Example: Adding comment to the overall branch_
@@ -132,14 +134,15 @@ When you are done with the review, if your workspace has <Link passHref href="/w
 
 ## What’s next?
 
- <div className={styles.row}>
-          <PageLink
-            image={AnalyticsManagerIcon}
-            title="3. Request implementation"
-            description="Learn how to request implementation"
-            callToAction={
-              new CallToAction("https://www.avo.app/docs/workflow/request-implementation")
-            }
-          />
-  </div>
-
+<div className={styles.row}>
+  <PageLink
+    image={AnalyticsManagerIcon}
+    title="3. Request implementation"
+    description="Learn how to request implementation"
+    callToAction={
+      new CallToAction(
+        'https://www.avo.app/docs/workflow/request-implementation',
+      )
+    }
+  />
+</div>

--- a/pages/workflow/review.mdx
+++ b/pages/workflow/review.mdx
@@ -132,13 +132,13 @@ When you are done with the review, if your workspace has <Link passHref href="/w
 
 ## What’s next?
 
- > <div className={styles.row}>
+ <div className={styles.row}>
           <PageLink
             image={AnalyticsManagerIcon}
             title="3. Request implementation"
             description="Learn how to request implementation"
             callToAction={
-              new CallToAction("/workflow/request-implementation")
+              new CallToAction("https://www.avo.app/docs/workflow/request-implementation")
             }
           />
   </div>

--- a/pages/workflow/validate.mdx
+++ b/pages/workflow/validate.mdx
@@ -24,33 +24,35 @@ For every source that has the Inspector installed, you can validate if the imple
 
 If you don’t have the Inspector installed yet, you can learn more about how to get started with the Inspector here:
 
- <div className={styles.row}>
-          <PageLink
-            image={AnalyticsManagerIcon}
-            title="Avo Inspector"
-            description="Use Inspector to improve your tracking plan health"
-            callToAction={
-              new CallToAction('https://www.avo.app/docs/data-design/start-using-inspector')
-            }
-          />
-  </div>
-
+<div className={styles.row}>
+  <PageLink
+    image={AnalyticsManagerIcon}
+    title="Avo Inspector"
+    description="Use Inspector to improve your tracking plan health"
+    callToAction={
+      new CallToAction(
+        'https://www.avo.app/docs/data-design/start-using-inspector',
+      )
+    }
+  />
+</div>
 
 ### Validate with the Inspector dashboard
 
 The Inspector dashboard compares your tracking calls to the Tracking Plan on your current branch. If the Inspector finds any discrepancies between the tracking calls and the Tracking Plan, an issue is shown on the dashboard.
 
 Here’s how you can validate tracking implementation for a particular branch using the Inspector dashboard:
+
 1. Head to the [Inspector dashboard](https://www.avo.app/schemas/default/inspector) in your workspace and switch to the branch you’d like to verify implementation for.
 2. In the Inspector dashboard header, pick the environment you’d like to validate (Development, Staging, or Production). When validating tracking changes that haven’t been released to production yet, you pick development or staging.
- 
-  <center>
-    <img
-          width="100%"
-          src={require('../../images/workflow/5.validate/dev-stag-production.png')}
-          alt="validate on inspector dashboard"
-    />
-  </center>
+
+<center>
+  <img
+    width="100%"
+    src={require('../../images/workflow/5.validate/dev-stag-production.png')}
+    alt="validate on inspector dashboard"
+  />
+</center>
 
 _Example: Inspector dashboard_
 
@@ -58,11 +60,11 @@ _Example: Inspector dashboard_
 
 <center>
   <img
-        width="100%"
-        src={require('../../images/workflow/5.validate/validate-dashboard-issue.png')}
-        alt="validate on inspector dashboard"
+    width="100%"
+    src={require('../../images/workflow/5.validate/validate-dashboard-issue.png')}
+    alt="validate on inspector dashboard"
   />
-</center> 
+</center>
 
 _Example: Discrepancies in the event tracking_
 
@@ -74,16 +76,18 @@ You can hover over the source pill in the events table, or click into the event,
 
 Learn more about how to read the Inspector implementation status:
 
- <div className={styles.row}>
-          <PageLink
-            image={AnalyticsManagerIcon}
-            title="Inspector implementation status"
-            description=""
-            callToAction={
-              new CallToAction('https://www.avo.app/docs/workspace/tracking-plan/implementation-status#inspector-implementation-status')
-            }
-          />
-  </div>
+<div className={styles.row}>
+  <PageLink
+    image={AnalyticsManagerIcon}
+    title="Inspector implementation status"
+    description=""
+    callToAction={
+      new CallToAction(
+        'https://www.avo.app/docs/workspace/tracking-plan/implementation-status#inspector-implementation-status',
+      )
+    }
+  />
+</div>
 
 # Validate implementation with Avo Functions
 
@@ -92,15 +96,17 @@ For all tracking implemented with Avo Functions, you can validate if the impleme
 If you’re not using Avo Functions already, you can learn more about how to get started here:
 
 <div className={styles.row}>
-          <PageLink
-            image={AnalyticsManagerIcon}
-            title="Quickstart: Avo Functions"
-            description="Start using Avo Functions"
-            callToAction={
-              new CallToAction('https://www.avo.app/docs/implementation/start-using-avo-functions')
-            }
-          />
-  </div>
+  <PageLink
+    image={AnalyticsManagerIcon}
+    title="Quickstart: Avo Functions"
+    description="Start using Avo Functions"
+    callToAction={
+      new CallToAction(
+        'https://www.avo.app/docs/implementation/start-using-avo-functions',
+      )
+    }
+  />
+</div>
 
 ### Validate with type-safety and runtime validation
 
@@ -109,50 +115,52 @@ All tracking code implemented with Avo Functions is type-safe and has built in r
 Learn more about how validations in Avo Functions work here:
 
 <div className={styles.row}>
-          <PageLink
-            image={DevIcon}
-            title="What's happening inside the Avo Functions"
-            description="Learn about how validation in Avo Functions work"
-            callToAction={
-              new CallToAction('https://www.avo.app/docs/implementation/avo-functions-overview#whats-happening-inside-the-avo-functions')
-            }
-          />
-  </div>
+  <PageLink
+    image={DevIcon}
+    title="What's happening inside the Avo Functions"
+    description="Learn about how validation in Avo Functions work"
+    callToAction={
+      new CallToAction(
+        'https://www.avo.app/docs/implementation/avo-functions-overview#whats-happening-inside-the-avo-functions',
+      )
+    }
+  />
+</div>
 
-### Validate with the Avo In-app Debugger 
+### Validate with the Avo In-app Debugger
 
 The Avo In-app Debugger is an addition on top of Avo Functions that gives you better visibility into which events are being sent, which properties are attached, and whether any issues were detected or not.
 
-
-  <center>
-      <img
-        height="500"
-        src={require('../../images/web-debugger-example.png')}
-        alt="Web debugger example"
-      />
-  </center>
-
+<center>
+  <img
+    height="500"
+    src={require('../../images/web-debugger-example.png')}
+    alt="Web debugger example"
+  />
+</center>
 
 _Example: Web debugger example_
 
-The Avo debugger is available on Web, iOS, Android and React Native. Learn more about the Avo debugger here: 
+The Avo debugger is available on Web, iOS, Android and React Native. Learn more about the Avo debugger here:
 
 <div className={styles.row}>
-          <PageLink
-            image={DevIcon}
-            title="Visual debuggers"
-            description="Learn about how Avo debugger works"
-            callToAction={
-              new CallToAction('https://www.avo.app/docs/explore-tracking-plan/start-using-visual-debuggers')
-            }
-          />
-  </div>
+  <PageLink
+    image={DevIcon}
+    title="Visual debuggers"
+    description="Learn about how Avo debugger works"
+    callToAction={
+      new CallToAction(
+        'https://www.avo.app/docs/explore-tracking-plan/start-using-visual-debuggers',
+      )
+    }
+  />
+</div>
 
 ### Validate with the Avo CLI
 
-The Avo CLI has a command, ´avo status´, that will report on where the Avo Functions are being called from, and which events have not been implemented yet. 
+The Avo CLI has a command, ´avo status´, that will report on where the Avo Functions are being called from, and which events have not been implemented yet.
 
-We recommend adding the ´avo status´ check to your CI pipeline, and configure it to throw an error if an event that is supposed to be sent with Avo Functions, is not found in the codebase. 
+We recommend adding the ´avo status´ check to your CI pipeline, and configure it to throw an error if an event that is supposed to be sent with Avo Functions, is not found in the codebase.
 
 ```sh
 > avo status
@@ -184,16 +192,15 @@ _Example: The ´avo status´ command in Avo CLI_
 You can learn more about using the Avo CLI in CI/CD here:
 
 <div className={styles.row}>
-          <PageLink
-            image={DevIcon}
-            title="Avo in CI/CD"
-            description="How to use the Avo CLI in CI/CD"
-            callToAction={
-              new CallToAction('https://www.avo.app/docs/implementation/avo-in-the-ci')
-            }
-          />
-  </div>
-
+  <PageLink
+    image={DevIcon}
+    title="Avo in CI/CD"
+    description="How to use the Avo CLI in CI/CD"
+    callToAction={
+      new CallToAction('https://www.avo.app/docs/implementation/avo-in-the-ci')
+    }
+  />
+</div>
 
 ### Validate with implementation status in the tracking plan
 
@@ -203,9 +210,9 @@ You can hover over the source pill in the events table, or click into the event,
 
 <center>
   <img
-        width="100%"
-        src={require('../../images/workflow/5.validate/pill.png')}
-        alt="hover the pill to see implementation status"
+    width="100%"
+    src={require('../../images/workflow/5.validate/pill.png')}
+    alt="hover the pill to see implementation status"
   />
 </center>
 
@@ -214,41 +221,39 @@ _Example: Implementation status in the event table of the tracking plan_
 You can also find a branch implementation status for Avo Functions in the top right corner of the branch review screen.
 
 <center>
-    <img
-          width="60%"
-          src={require('../../images/workflow/5.validate/event-implemented.png')}
-          alt="hover the pill to see implementation status"
-    />
-</center> 
-
+  <img
+    width="60%"
+    src={require('../../images/workflow/5.validate/event-implemented.png')}
+    alt="hover the pill to see implementation status"
+  />
+</center>
 
 _Example: Implementation status on the branch review screen_
-
 
 Learn more about how to read the Avo Functions implementation status:
 
 <div className={styles.row}>
-          <PageLink
-            image={DevIcon}
-            title="Avo Functions implementation status"
-            description="Learn how to read the Avo Functions implementation status"
-            callToAction={
-              new CallToAction('https://www.avo.app/docs/workspace/tracking-plan/implementation-status#avo-functions-implementation-status')
-            }
-          />
-  </div>
-
+  <PageLink
+    image={DevIcon}
+    title="Avo Functions implementation status"
+    description="Learn how to read the Avo Functions implementation status"
+    callToAction={
+      new CallToAction(
+        'https://www.avo.app/docs/workspace/tracking-plan/implementation-status#avo-functions-implementation-status',
+      )
+    }
+  />
+</div>
 
 ## What’s next?
 
- <div className={styles.row}>
-          <PageLink
-            image={AnalyticsManagerIcon}
-            title="6. Merge branch and Publish"
-            description="Learn how to Merge branch and Publish your tracking plan updates to schema registries"
-            callToAction={
-              new CallToAction("https://www.avo.app/docs/workflow/merge-publish")
-            }
-          />
-  </div>
-
+<div className={styles.row}>
+  <PageLink
+    image={AnalyticsManagerIcon}
+    title="6. Merge branch and Publish"
+    description="Learn how to Merge branch and Publish your tracking plan updates to schema registries"
+    callToAction={
+      new CallToAction('https://www.avo.app/docs/workflow/merge-publish')
+    }
+  />
+</div>

--- a/pages/workflow/validate.mdx
+++ b/pages/workflow/validate.mdx
@@ -241,13 +241,13 @@ Learn more about how to read the Avo Functions implementation status:
 
 ## What’s next?
 
- > <div className={styles.row}>
+ <div className={styles.row}>
           <PageLink
             image={AnalyticsManagerIcon}
             title="6. Merge branch and Publish"
             description="Learn how to Merge branch and Publish your tracking plan updates to schema registries"
             callToAction={
-              new CallToAction("/workflow/merge-publish")
+              new CallToAction("https://www.avo.app/docs/workflow/merge-publish")
             }
           />
   </div>

--- a/pages/workflow/validate.mdx
+++ b/pages/workflow/validate.mdx
@@ -31,7 +31,7 @@ If you don’t have the Inspector installed yet, you can learn more about how to
     description="Use Inspector to improve your tracking plan health"
     callToAction={
       new CallToAction(
-        'https://www.avo.app/docs/data-design/start-using-inspector',
+        '/data-design/start-using-inspector',
       )
     }
   />
@@ -83,7 +83,7 @@ Learn more about how to read the Inspector implementation status:
     description=""
     callToAction={
       new CallToAction(
-        'https://www.avo.app/docs/workspace/tracking-plan/implementation-status#inspector-implementation-status',
+        '/workspace/tracking-plan/implementation-status#inspector-implementation-status',
       )
     }
   />
@@ -102,7 +102,7 @@ If you’re not using Avo Functions already, you can learn more about how to get
     description="Start using Avo Functions"
     callToAction={
       new CallToAction(
-        'https://www.avo.app/docs/implementation/start-using-avo-functions',
+        '/implementation/start-using-avo-functions',
       )
     }
   />
@@ -121,7 +121,7 @@ Learn more about how validations in Avo Functions work here:
     description="Learn about how validation in Avo Functions work"
     callToAction={
       new CallToAction(
-        'https://www.avo.app/docs/implementation/avo-functions-overview#whats-happening-inside-the-avo-functions',
+        '/implementation/avo-functions-overview#whats-happening-inside-the-avo-functions',
       )
     }
   />
@@ -150,7 +150,7 @@ The Avo debugger is available on Web, iOS, Android and React Native. Learn more 
     description="Learn about how Avo debugger works"
     callToAction={
       new CallToAction(
-        'https://www.avo.app/docs/explore-tracking-plan/start-using-visual-debuggers',
+        '/explore-tracking-plan/start-using-visual-debuggers',
       )
     }
   />
@@ -197,7 +197,7 @@ You can learn more about using the Avo CLI in CI/CD here:
     title="Avo in CI/CD"
     description="How to use the Avo CLI in CI/CD"
     callToAction={
-      new CallToAction('https://www.avo.app/docs/implementation/avo-in-the-ci')
+      new CallToAction('/implementation/avo-in-the-ci')
     }
   />
 </div>
@@ -239,7 +239,7 @@ Learn more about how to read the Avo Functions implementation status:
     description="Learn how to read the Avo Functions implementation status"
     callToAction={
       new CallToAction(
-        'https://www.avo.app/docs/workspace/tracking-plan/implementation-status#avo-functions-implementation-status',
+        '/workspace/tracking-plan/implementation-status#avo-functions-implementation-status',
       )
     }
   />
@@ -253,7 +253,7 @@ Learn more about how to read the Avo Functions implementation status:
     title="6. Merge branch and Publish"
     description="Learn how to Merge branch and Publish your tracking plan updates to schema registries"
     callToAction={
-      new CallToAction('https://www.avo.app/docs/workflow/merge-publish')
+      new CallToAction('/workflow/merge-publish')
     }
   />
 </div>


### PR DESCRIPTION
Fixes broken "What's next" links in the workflow docs, based on a report from a customer: https://app.asana.com/0/1199661690807061/1202883037083484/f

Main changes in a0ae54f, only some reformatting happening in 6e498a3.