### PR TITLE
Fix actions link

### DIFF
--- a/pages/workspace/connect-inspector-to-segment.mdx
+++ b/pages/workspace/connect-inspector-to-segment.mdx
@@ -31,13 +31,10 @@ You send data directly to Segment and it notifies Avo Inspector about your track
     alt="Data flow from Segment to Avo Inspector"
   />
 </center>
-If you are using Avo Codegen and Avo generated code, see <Link
-  passHref
-  href="#diagram-of-the-data-flow-when-sending-to-segment-with-avo-generated-code"
-  passHref
->
-  <a>diagram of the data flow when using Avo Codegen</a>
-</Link>
+If you are using Avo Codegen and Avo generated code, see
+<a href="#diagram-of-the-data-flow-when-sending-to-segment-with-avo-generated-code">
+  diagram of the data flow when using Avo Codegen
+</a>
 
 ## Guide to connect Segment and Avo Inspector
 

--- a/pages/workspace/tracking-plan/events.mdx
+++ b/pages/workspace/tracking-plan/events.mdx
@@ -24,7 +24,7 @@ An event is defined in the Events section of the Tracking plan and can be organi
 - A <Link passHref href="/data-design/defining-descriptive-events-and-properties#events-1"><a>_Description_</a></Link> with information about the event beyond what the name includes (optional but highly recommended)
 - The <Link passHref href="/data-design/event-triggers"><a>_Trigger(s)_</a></Link> that describe both visually and in words all the user or system actions that trigger the event (optional but highly recommended)
 - The <Link passHref href="/workspace/connections#a-namesourcesa-sources-where-the-data-comes-from"><a>_Source(s)_</a></Link> that the event should be sent from
-- The <Link passHref href="#actions"><a>_Actions(s)_</a></Link> associated with the event
+- The <a href="#actions">_Actions(s)_</a> associated with the event
 - The <Link passHref href="/workspace/tracking-plan/metrics"><a>_Metrics(s)_</a></Link> related to the event (optional)
 - The <Link passHref href="/data-design/organizing-metrics-and-events#a-namecategoriesa-categories"><a>_Category(s)_</a></Link> that the event is a part of (optional)
 - The _Tags_ associated with the event


### PR DESCRIPTION
The anchors used to link to /#... instead of being relative to the current document