### PR TITLE
Fix some links

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -380,6 +380,7 @@ AvoSystemProperties.t
 Js.t
 CustomDestination
 reportFailureAs
+myapp.com
  - pages/data-design/defining-descriptive-events-and-properties.mdx
 facebook
  - pages/explore-tracking-plan/issue-types-in-inspector.mdx

--- a/pages/data-design/avo-tracking-plan/events.mdx
+++ b/pages/data-design/avo-tracking-plan/events.mdx
@@ -32,7 +32,7 @@ An event is defined in the Events section of the Tracking plan and can be organi
 
 ## Sources
 
-Add all sources you want the event to be sent from to the event in Avo. If you want the event to be implemented with [Avo Codegen](https://www.avo.app/docs/implementation/avo-codegen-overview), make sure "Implement with Codegen" is checked. Having "Implement with Codegen" checked adds the event to your type-safe Avo Codegen file for that source. If you don't want the event to be implemented with Avo Codegen, leave "Implement with Codegen" unchecked.
+Add all sources you want the event to be sent from to the event in Avo. If you want the event to be implemented with [Avo Codegen](/implementation/avo-codegen-overview), make sure "Implement with Codegen" is checked. Having "Implement with Codegen" checked adds the event to your type-safe Avo Codegen file for that source. If you don't want the event to be implemented with Avo Codegen, leave "Implement with Codegen" unchecked.
 
 ![The sources the event should be sent from](/docs/images/workspace/tracking-plan/event-sources.png)
 

--- a/pages/data-design/avo-tracking-plan/implementation-status.mdx
+++ b/pages/data-design/avo-tracking-plan/implementation-status.mdx
@@ -1,5 +1,4 @@
 import { Callout } from 'nextra/components';
-import Link from 'next/link';
 
 # Implementation Status
 
@@ -24,7 +23,7 @@ Avo Codegen implementation status can have four states:
 3. Never sent correctly
 4. Never seen
 
-Learn more about <Link passHref href="/implementation/start-using-avo-codegen">how to start using Avo Codegen in this doc</Link>.
+Learn more about [how to start using Avo Codegen in this doc](/implementation/start-using-avo-codegen).
 
 ## Inspector implementation status
 

--- a/pages/data-design/avo-tracking-plan/index.mdx
+++ b/pages/data-design/avo-tracking-plan/index.mdx
@@ -6,20 +6,20 @@ code from and validate your data against.
 
 The following sections build up your Avo workspace:
 
-- [Tracking Plan Events]("/workspace/tracking-plan/events"): where all events structures are defined
+- [Tracking Plan Events](/workspace/tracking-plan/events): where all events structures are defined
 
-- [Tracking Plan Properties]("/workspace/tracking-plan/properties"): where all properties are defined
+- [Tracking Plan Properties](/workspace/tracking-plan/properties): where all properties are defined
 
-- [Tracking Plan Metrics]("/workspace/tracking-plan/metrics"): where all metrics are defined
+- [Tracking Plan Metrics](/workspace/tracking-plan/metrics): where all metrics are defined
 
-- [Tracking Plan Publishing]("/workspace/tracking-plan/publishing"): sync your tracking plan with the one in your analytics platform
+- [Tracking Plan Publishing](/workspace/tracking-plan/publishing): sync your tracking plan with the one in your analytics platform
 
-- [Connection Setup]("/workspace/connections"): configure sources and destinations, including setting up Inspector and Avo Codegen
+- [Connection Setup](/workspace/connections): configure sources and destinations, including setting up Inspector and Avo Codegen
 
-- [Codegen Reference]("/workspace/implement"): source specific event reference for Avo Codegen, with code snippets that help
+- [Codegen Reference](/workspace/implement): source specific event reference for Avo Codegen, with code snippets that help
   you implement
 
-- [Inspector]("/workspace/inspector"): get a report of the state of your tracking and get alerted when new issues are
+- [Inspector](/workspace/inspector): get a report of the state of your tracking and get alerted when new issues are
   detected
 
 ![Example tracking plan in Avo](/docs/images/workspace/nav-tracking-plan.png)

--- a/pages/data-design/best-practices/naming-conventions.mdx
+++ b/pages/data-design/best-practices/naming-conventions.mdx
@@ -124,7 +124,7 @@ In addition to the support that's built into the Avo app, the Avo review workflo
 
 The typical Avo customer has years of tracking in place when they start using Avo (and some analytics debt to pay down...). That is why Avo not only has prescriptive tools in place, but also ones that inspect and detect:
 
-1. The **[Avo issue reporter](https://www.avo.app/docs/workspace/tracking-plan#a-nametracking-plan-issue-reportera-the-tracking-plan-issue-reporter) reports events that break casing convention** in your tracking plan casing:
+1. The **[Avo issue reporter](/workspace/tracking-plan#a-nametracking-plan-issue-reportera-the-tracking-plan-issue-reporter) reports events that break casing convention** in your tracking plan casing:
 
    So for example if you upload your current tracking plan in Avo, the issue reporter will highlight naming issues:
 

--- a/pages/faqs/faq-inspector.mdx
+++ b/pages/faqs/faq-inspector.mdx
@@ -2,8 +2,8 @@
 
 ### Do I need to replace my existing tracking code?
 
-No, you don’t! The [Avo Inspector SDK]("/implementation/avo-inspector-sdk-reference")
-is designed to not require any changes to your existing tracking code. [Read more on setting up the SDK here]("/implementation/setup-inspector-sdk")
+No, you don’t! The [Avo Inspector SDK](/implementation/avo-inspector-sdk-reference)
+is designed to not require any changes to your existing tracking code. [Read more on setting up the SDK here](/implementation/setup-inspector-sdk)
 .
 
 ### Do I need to add Avo to my privacy policy?
@@ -41,13 +41,13 @@ Avo doesn’t need to know the actual values, we only need to understand the sha
 
 ### What does Avo do with my data?
 
-The [Avo Inspector SDK]("/implementation/avo-inspector-sdk-reference")
-analyzes your user data and delivers metadata about the user data to Avo’s servers. Based on that metadata we build your tracking plan and [alert on any issues]("/workspace/inspector#issue-types")
+The [Avo Inspector SDK](/implementation/avo-inspector-sdk-reference)
+analyzes your user data and delivers metadata about the user data to Avo’s servers. Based on that metadata we build your tracking plan and [alert on any issues](/workspace/inspector#issue-types)
 .
 
 ### Does Avo batch events in the SDK?
 
-Avo Inspector SDKs does batch events before sending metadata about them to Avo’s servers. The details of the batching may vary between platforms, [read more in the docs for the SDKs]("/implementation/avo-inspector-sdk-reference")
+Avo Inspector SDKs does batch events before sending metadata about them to Avo’s servers. The details of the batching may vary between platforms, [read more in the docs for the SDKs](/implementation/avo-inspector-sdk-reference)
 .
 
 ### What do I do if I don't have a central wrapper where I can plug in the SDK?
@@ -61,7 +61,7 @@ You can receive email alerts when new issues are detected. Head to the Issues da
 ### When will the "bubble" from the In-App Inspector (aka Avo Debuggers) be visible in my app?
 
 The "bubble" of the [In-App Inspector (aka Avo Debuggers)
-](https://www.avo.app/docs/explore-tracking-plan/start-using-visual-debuggers) is visible when Avo is initialized in `dev` mode. The details differ between platforms as follows:
+](/explore-tracking-plan/start-using-visual-debuggers) is visible when Avo is initialized in `dev` mode. The details differ between platforms as follows:
 
 On Android and iOS the bubble will be shown if you include Inspector SDK and initialize it with the environment parameter set to `dev`.
 On Web the bubble will be shown if you are using Avo Codegen and the env parameter in `initAvo` is set to `dev`.

--- a/pages/faqs/yes-you-can-faq.mdx
+++ b/pages/faqs/yes-you-can-faq.mdx
@@ -10,15 +10,15 @@ Yes, you can! Avo does not collect any user data. We only collect metadata about
 
 ### Can I use Avo to fix analytics issues?
 
-Yes, you can! The [Avo Inspector SDK]("/implementation/avo-inspector-sdk-reference")
-will automatically [monitor the health of your current tracking]("/workspace/inspector")
+Yes, you can! The [Avo Inspector SDK](/implementation/avo-inspector-sdk-reference)
+will automatically [monitor the health of your current tracking](/workspace/inspector)
 and suggest fixes for issues such as missing events or properties, casing inconsistencies, property type mismatches, significant difference in volumes between platforms and many more.
 
 ### Can I use Avo to generate analytics tracking code?
 
 Yes, you can! We offer a few different ways to do this. You can pull the [
-analytics wrappers from the CLI]("/implementation/cli#step-3-pull-generated-analytics-wrappers-from-avo")
-, or you can copy them from [within the Avo UI]("/workspace/implement#a-nameavo-filea-get-the-avo-file")
+analytics wrappers from the CLI](/implementation/cli#step-3-pull-generated-analytics-wrappers-from-avo)
+, or you can copy them from [within the Avo UI](/workspace/implement#a-nameavo-filea-get-the-avo-file)
 .
 
 ### Can I use Inspector on my dev environment? What about production?
@@ -31,19 +31,19 @@ Yes, you can! Validation logs and warnings are by default only sent in the devel
 
 ### Can I sort and organize my events and analytics in Avo?
 
-Yes, you can! We recommend setting up and [utilizing Categories]("/data-design/organizing-metrics-and-events")
+Yes, you can! We recommend setting up and [utilizing Categories](/data-design/organizing-metrics-and-events)
 and tags to keep track of events from different product features.
 
 ### Can I implement platform-specific events or metrics?
 
 Yes, you can! Within the Avo UI, you will be able to select platform-specific sources and destinations if you are on the Team or Enterprise Plans. For more information about source availability, [
-check out what we support here]("/workspace/connections#a-namesourcesa-sources-where-the-data-comes-from")
+check out what we support here](/workspace/connections#a-namesourcesa-sources-where-the-data-comes-from)
 .
 
 ### Can I use Avo with my git workflow?
 
-Yes you can! Every team works differently, but we’ve put together an [example workflow here]("/implementation/avo-and-git")
-. Our [CLI documentation]("/implementation/cli#using-avo-branches")
+Yes you can! Every team works differently, but we’ve put together an [example workflow here](/implementation/avo-and-git)
+. Our [CLI documentation](/implementation/cli#using-avo-branches)
 has more information on specific commands.
 
 ### Can I use Avo to draft changes to my tracking plan in isolation?
@@ -52,174 +52,174 @@ Yes, you can! We have a branched workflow and encourage all users to never direc
 
 ### Can I use Avo to collaborate with my teammates?
 
-Yes, you can, and we hope you do! Check out <a target="_blank" rel="noopener noreferrer" href="https://www.avo.app/blog/introducing-branch-collaborators">this post</a> for how we support collaboration in our branches.
+Yes, you can, and we hope you do! Check out [this post](https://www.avo.app/blog/introducing-branch-collaborators).
 
 ### Can I use Avo with my existing analytics tracking?
 
-Yes, you can! The [Avo Inspector SDK]("/implementation/avo-inspector-sdk-reference")
+Yes, you can! The [Avo Inspector SDK](/implementation/avo-inspector-sdk-reference)
 is designed to not require any changes to your existing tracking code.
 
 ### Can I use Avo with custom analytics endpoints?
 
-Yes, you can! For custom pipelines and APIs, this is the perfect way to integrate with Avo. Check out our docs on it [here]("/implementation/destinations")
+Yes, you can! For custom pipelines and APIs, this is the perfect way to integrate with Avo. Check out our docs on it [here](/implementation/destinations)
 .
 
 ### Can I use Avo with Segment?
 
-Yes, you can! [Check out our integration here]("/data-design/analytics#segment")
+Yes, you can! [Check out our integration here](/data-design/analytics#segment)
 .
 
 ### Can I use Avo with Mixpanel?
 
-Yes, you can! [Check out our integration here]("/data-design/analytics#avo-mixpanel")
+Yes, you can! [Check out our integration here](/data-design/analytics#avo-mixpanel)
 .
 
 ### Can I use Avo with Amplitude?
 
-Yes, you can! [Check out our integration here]("/data-design/analytics#avo-amplitude")
+Yes, you can! [Check out our integration here](/data-design/analytics#avo-amplitude)
 .
 
 ### Can I use Avo with AppsFlyer?
 
-Yes, you can! [Check out our integration here]("/data-design/analytics#appsflyer")
+Yes, you can! [Check out our integration here](/data-design/analytics#appsflyer)
 .
 
 ### Can I use Avo with Facebook Analytics?
 
-Yes, you can! [Check out our integration here]("/data-design/analytics#facebook-analytics")
+Yes, you can! [Check out our integration here](/data-design/analytics#facebook-analytics)
 .
 
 ### Can I use Avo with Firebase Analytics?
 
-Yes, you can! [Check out our integration here]("/data-design/analytics#firebase-analytics")
+Yes, you can! [Check out our integration here](/data-design/analytics#firebase-analytics)
 .
 
 ### Can I use Avo with FullStory?
 
-Yes, you can! [Check out our integration here]("/data-design/analytics#fullstory")
+Yes, you can! [Check out our integration here](/data-design/analytics#fullstory)
 .
 
 ### Can I use Avo with Intercom?
 
-Yes, you can! [Check out our integration here]("/data-design/analytics#intercom")
+Yes, you can! [Check out our integration here](/data-design/analytics#intercom)
 .
 
 ### Can I publish my Avo tracking plan to Segment Protocols?
 
 Yes, you can! We integrate directly with Segment Protocols. [
-Find out more here]("/workspace/tracking-plan/publishing#a-namesegment-protocolsa-segment-protocols")
+Find out more here](/workspace/tracking-plan/publishing#a-namesegment-protocolsa-segment-protocols)
 .
 
 ### Can I publish my Avo tracking plan to RudderStack?
 
-Yes, you can! We integrate directly with RudderStack. [Find out more here]("/workspace/tracking-plan/publishing#rudderstack")
+Yes, you can! We integrate directly with RudderStack. [Find out more here](/workspace/tracking-plan/publishing#rudderstack)
 .
 
 ### Can I publish my Avo tracking plan to mParticle Data Master?
 
-Yes, you can! We integrate directly with mParticle Data Master. [Find out more here]("/workspace/tracking-plan/publishing#mparticle")
+Yes, you can! We integrate directly with mParticle Data Master. [Find out more here](/workspace/tracking-plan/publishing#mparticle)
 .
 
 ### Can I publish my Avo tracking plan to Mixpanel Lexicon?
 
 Yes, you can! We integrate with Mixpanel Lexicon. [
-Find out more here]("/workspace/tracking-plan/publishing#a-namemixpanel-lexicona-mixpanel-lexicon")
+Find out more here](/workspace/tracking-plan/publishing#a-namemixpanel-lexicona-mixpanel-lexicon)
 .
 
 ### Can I publish my Avo tracking plan to Snowplow?
 
-Yes, you can! We integrate directly with Snowplow. [Find out more here]("/workspace/tracking-plan/publishing#snowplow")
+Yes, you can! We integrate directly with Snowplow. [Find out more here](/workspace/tracking-plan/publishing#snowplow)
 .
 
 ### Can I publish my Avo tracking plan to Amplitude Govern?
 
 Yes, you can! We integrate with Amplitude’s Govern (Taxonomy) tool. [
-Check out our integration here]("/workspace/tracking-plan/publishing#a-nameamplitude-governa-amplitude-govern")
+Check out our integration here](/workspace/tracking-plan/publishing#a-nameamplitude-governa-amplitude-govern)
 .
 
 ### Can I publish my Avo tracking plan to my custom tracking tool?
 
-Yes, you can! [Check out our Webhook integration here]("/workspace/tracking-plan/publishing#a-namewebhooka-webhook")
+Yes, you can! [Check out our Webhook integration here](/workspace/tracking-plan/publishing#a-namewebhooka-webhook)
 .
 
 ### Can I implement Avo with JavaScript?
 
-Yes, you can! For more information on the languages we support, [check out our docs here]("/implementation/supported-programming-languages")
+Yes, you can! For more information on the languages we support, [check out our docs here](/implementation/supported-programming-languages)
 .
 
 ### Can I implement Avo with TypeScript?
 
-Yes, you can! For more information on the languages we support, [check out our docs here]("/implementation/supported-programming-languages")
+Yes, you can! For more information on the languages we support, [check out our docs here](/implementation/supported-programming-languages)
 .
 
 ### Can I implement Avo with ReasonML?
 
-Yes, you can! For more information on the languages we support, [check out our docs here]("/implementation/supported-programming-languages")
+Yes, you can! For more information on the languages we support, [check out our docs here](/implementation/supported-programming-languages)
 .
 
 ### Can I implement Avo with React Native?
 
-Yes, you can! For more information on the languages we support, [check out our docs here]("/implementation/supported-programming-languages")
+Yes, you can! For more information on the languages we support, [check out our docs here](/implementation/supported-programming-languages)
 .
 
 ### Can I implement Avo with Objective-C?
 
-Yes, you can! For more information on the languages we support, [check out our docs here]("/implementation/supported-programming-languages")
+Yes, you can! For more information on the languages we support, [check out our docs here](/implementation/supported-programming-languages)
 .
 
 ### Can I implement Avo with Swift?
 
-Yes, you can! For more information on the languages we support, [check out our docs here]("/implementation/supported-programming-languages")
+Yes, you can! For more information on the languages we support, [check out our docs here](/implementation/supported-programming-languages)
 .
 
 ### Can I implement Avo with Java?
 
-Yes, you can! For more information on the languages we support, [check out our docs here]("/implementation/supported-programming-languages")
+Yes, you can! For more information on the languages we support, [check out our docs here](/implementation/supported-programming-languages)
 .
 
 ### Can I implement Avo with Kotlin?
 
-Yes, you can! For more information on the languages we support, [check out our docs here]("/implementation/supported-programming-languages")
+Yes, you can! For more information on the languages we support, [check out our docs here](/implementation/supported-programming-languages)
 .
 
 ### Can I implement Avo with Node.js?
 
-Yes, you can! For more information on the languages we support, [check out our docs here]("/implementation/supported-programming-languages")
+Yes, you can! For more information on the languages we support, [check out our docs here](/implementation/supported-programming-languages)
 .
 
 ### Can I implement Avo with Python?
 
-Yes, you can! For more information on the languages we support, [check out our docs here]("/implementation/supported-programming-languages")
+Yes, you can! For more information on the languages we support, [check out our docs here](/implementation/supported-programming-languages)
 .
 
 ### Can I implement Avo with Ruby?
 
-Yes, you can! For more information on the languages we support, [check out our docs here]("/implementation/supported-programming-languages")
+Yes, you can! For more information on the languages we support, [check out our docs here](/implementation/supported-programming-languages)
 .
 
 ### Can I implement Avo with PHP?
 
-Yes, you can! For more information on the languages we support, [check out our docs here]("/implementation/supported-programming-languages")
+Yes, you can! For more information on the languages we support, [check out our docs here](/implementation/supported-programming-languages)
 .
 
 ### Can I implement Avo with Unity (C#)?
 
-Yes, you can! For more information on the languages we support, [check out our docs here]("/implementation/supported-programming-languages")
+Yes, you can! For more information on the languages we support, [check out our docs here](/implementation/supported-programming-languages)
 .
 
 ### Can I export my tracking plan from Avo?
 
-Yes, you can! You can use our [publishing feature]("/workspace/tracking-plan/publishing")
+Yes, you can! You can use our [publishing feature](/workspace/tracking-plan/publishing)
 to export it on either JSON schema format with a Webhook or the Amplitude/Mixpanel/Segment formats.
 
 ### Can I document my metrics in context with my tracking plan?
 
-Yes, you can! We recommend [defining metrics]("/workspace/tracking-plan/metrics")
+Yes, you can! We recommend [defining metrics](/workspace/tracking-plan/metrics)
 before adding events to your tracking plan. In Avo, they are connected to events and help stakeholders understand why this event is being tracked.
 
 ### Can I use Avo to QA my events?
 
-Yes you can! Avo’s [mobile debuggers]("/explore-tracking-plan/start-using-visual-debuggers")
+Yes you can! Avo’s [mobile debuggers](/explore-tracking-plan/start-using-visual-debuggers)
 make it easier than ever to test and QA event implementations.
 
 ### Can I reuse a definition of a property in Avo?
@@ -228,23 +228,23 @@ Yes you can! Avo’s property library is global in scope, so you don’t have to
 
 ### Can I define what property values are allowed in Avo?
 
-Yes you can! [Property constraints]("/data-design/defining-descriptive-events-and-properties#a-nameproperty-constraintsa-property-constraints")
+Yes you can! [Property constraints](/data-design/defining-descriptive-events-and-properties#a-nameproperty-constraintsa-property-constraints)
 within Avo allow you to create predefined rules about the values you will allow for any given property. Say goodbye to the days of nonsense metadata like “age” = “-1”.
 
 ### Can I use Avo in my unit tests?
 
-Yes you can! [Avo in unit tests]("/implementation/avo-and-unit-tests")
+Yes you can! [Avo in unit tests](/implementation/avo-and-unit-tests)
 can be initialized with a noop flag that disables network requests and only run data validation.
 
 ### Can I add descriptions to my events and properties with Avo?
 
-Yes you can! [Defining descriptive events and properties]("/data-design/defining-descriptive-events-and-properties#a-namedescriptionsa-descriptions-for-events-and-properties")
+Yes you can! [Defining descriptive events and properties](/data-design/defining-descriptive-events-and-properties#a-namedescriptionsa-descriptions-for-events-and-properties)
 is a best practice for keeping all your current and future teammates on the same page.
 
 ### Can I use Avo to help stick to my naming convention?
 
-Yes, you can! In Inspector, you will see issues when naming conventions have been violated. You will also receive [feedback in event and property naming modals]("/data-design/defining-descriptive-events-and-properties#a-namenaming-conventionsa-naming-conventions-for-events-and-properties")
-and a summary in our [issue reporter]("/workspace/tracking-plan/issue-reporter")
+Yes, you can! In Inspector, you will see issues when naming conventions have been violated. You will also receive [feedback in event and property naming modals](/data-design/defining-descriptive-events-and-properties#a-namenaming-conventionsa-naming-conventions-for-events-and-properties)
+and a summary in our [issue reporter](/workspace/tracking-plan/issue-reporter)
 within your tracking plan.
 
-[Get in touch]("/help/troubleshooting") for more information.
+[Get in touch](/help/troubleshooting) for more information.

--- a/pages/implementation/avo-codegen-tech-deep-dive.mdx
+++ b/pages/implementation/avo-codegen-tech-deep-dive.mdx
@@ -23,7 +23,7 @@ The generated file is the best source of truth when looking for implementation d
   Make sure all the events you want to implement using Codegen have the source
   attached to it, where "Implement with Codegen" has been checked. Learn more
   about how to [configure events in your tracking plan
-  here](https://www.avo.app/docs/workspace/tracking-plan/events#sources).
+  here](/workspace/tracking-plan/events#sources).
 </Callout>
 
 ### Avo Command Line Interface

--- a/pages/implementation/cli.mdx
+++ b/pages/implementation/cli.mdx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-
 # Using the Avo CLI
 
 The [Avo command line interface](https://github.com/avohq/avo) provides a way to pull custom analytics wrappers from Avo. The CLI is designed to make developers more productive when implementing analytics.
@@ -108,7 +106,7 @@ info Looking for events in src/main/java/app/avo/musicplayerexample/Player.kt
 
 ### Interface files
 
-Some languages allow you to generate multiple files, for example Objective-C requires it and you can enable it in Kotlin and Swift using on-demand feature flags. <Link passHref href="/cli#step-3-pull-generated-analytics-wrappers-from-avo" passHref>see --forceFeatures pull flag above</Link>
+Some languages allow you to generate multiple files, for example Objective-C requires it and you can enable it in Kotlin and Swift using on-demand feature flags. [see --forceFeatures pull flag above](/cli#step-3-pull-generated-analytics-wrappers-from-avo).
 
 When initializing a source with CLI v3.2.0 and later it will ask you to specify a separate path for the interface file.
 

--- a/pages/implementation/start-using-avo-codegen.mdx
+++ b/pages/implementation/start-using-avo-codegen.mdx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-
 # How to set up and use Codegen
 
 Integrating Avo with your app or website can begin as soon as you create an Avo account, and requires three steps:
@@ -65,34 +63,21 @@ Note that the _Production API Key_ and _Development API Key_ are not required fo
 
 If you use multiple analytics tools, you should repeat this process and create a destination for every analytics tool.
 
-<img
-  src={'/docs/images/best-practices/avo-functions-alongside-existing-tracking/destination-config.png'}
-  alt="Destination configuration"
-/>
-<center>
-  <i>
-    A Destination for My Analytics SDK, which is a destination used on MyApp.com
-  </i>
-</center>
+![Destination configuration](/docs/images/best-practices/avo-functions-alongside-existing-tracking/destination-config.png)
 
-<br />
-<br />
+_A Destination for My Analytics SDK, which is a destination used on MyApp.com_
 
 **All set!**
 
 Here we've configured a Source, sending to a Custom Destination called My Analytics SDK:
 
-<img
-  src={'/docs/images/best-practices/avo-functions-alongside-existing-tracking/connections.png'}
-  alt="Connections configuration"
-/>
-<center>
-  <i>Our Source and Destination</i>
-</center>
+![Connections configuration](/docs/images/best-practices/avo-functions-alongside-existing-tracking/connections.png)
+
+_Our Source and Destination_
 
 #### Configure events
 
-Head to the Tracking Plan tab. If no events exist in your tracking plan yet you can either [import your existing tracking plan](https://www.avo.app/docs/workspace/tracking-plan/importing) or [define events in the Tracking Plan](https://www.avo.app/docs/data-design/start-data-design#defining-and-configuring-events). Make sure to attach the source you'll be implementing to all events you want to implement. Learn more about [attaching sources to events here](https://www.avo.app/docs/workspace/tracking-plan/events#sources).
+Head to the Tracking Plan tab. If no events exist in your tracking plan yet you can either [import your existing tracking plan](/workspace/tracking-plan/importing) or [define events in the Tracking Plan](/data-design/start-data-design#defining-and-configuring-events). Make sure to attach the source you'll be implementing to all events you want to implement. Learn more about [attaching sources to events here](/workspace/tracking-plan/events#sources).
 
 ### 2. Install Avo to your project
 
@@ -231,11 +216,11 @@ Avo.initAvo({ env: Avo.AvoEnv.Dev }, {}, myAnalyticsSDKBridge);
 
 <br />
 
-Detailed instructions on how to initialize Avo with Custom Destinations for all other programming languages and platforms supported by Avo <Link passHref href="/implementation/destinations">can be found here</Link>.
+Detailed instructions on how to initialize Avo with Custom Destinations for all other programming languages and platforms supported by Avo [can be found here](/implementation/destinations).
 
 #### Send an event
 
-Now we're ready to start implementing reliably analytics tracking with Codegen. Every Event defined in our <Link passHref href="/workspace/tracking-plan">Tracking Plan on avo.app</Link> has it's own function in Codegen file.
+Now we're ready to start implementing reliably analytics tracking with Codegen. Every Event defined in our [Tracking Plan on avo.app](/workspace/tracking-plan) has it's own function in Codegen file.
 
 Let's say we have defined the "App Opened" event in our Tracking Plan in Avo, with two Event Properties, "Client" and "Screen Name". Here's how we would send the event using Codegen:
 
@@ -247,4 +232,4 @@ Avo.appOpened({ client: 'Web', screenName: 'Home Screen' });
 
 When the Avo Function is called Avo will run validation on the event properties, making sure they fit the spec defined in the Tracking Plan in Avo. Note that this validation is only run in development mode. If you are using a Custom destination Avo passes the event name and properties to the logEvent function in the Custom Destination interface defined above, otherwise it will pass the event directly to the analytics tool defined in your destination.
 
-You can find tailor made documentation for your Codegen, based on your Tracking Plan, in the <Link passHref href="/workspace/implement#a-nameimplement-actionsa-implement-events">Codegen tab</Link> in [your Avo workspace](https://www.avo.app/welcome).
+You can find tailor made documentation for your Codegen, based on your Tracking Plan, in the [Codegen tab](/workspace/implement#a-nameimplement-actionsa-implement-events) in [your Avo workspace](https://www.avo.app/welcome).

--- a/pages/inspector/inspector-issues-view.mdx
+++ b/pages/inspector/inspector-issues-view.mdx
@@ -13,7 +13,7 @@ The Inspector issues view displays information about anomalies and discrepancies
 </center>
 
 Each issue in the table represents an issue on a particular event, or a particular property contained within an event. In the table you will see:
-- The issue type – for example unexpected event or inconsistent property types, [(see list of issue types in Inspector)](https://www.avo.app/docs/explore-tracking-plan/issue-types-in-inspector)
+- The issue type – for example unexpected event or inconsistent property types, [(see list of issue types in Inspector)](/explore-tracking-plan/issue-types-in-inspector)
 - The name of the event and property impacted
 - Sources impacted
 - Issue timing – when it was first and last seen
@@ -39,7 +39,7 @@ To narrow down your search to your most relevant issues, you can filter by the f
   />
 </center>
 
-> 💡 We are actively working on adding more filter options, and you can expect more filters in the near future. If there’s anything specific you’d like to be able to filter by, please [let us know](https://www.avo.app/docs/help/troubleshooting). 
+> 💡 We are actively working on adding more filter options, and you can expect more filters in the near future. If there’s anything specific you’d like to be able to filter by, please [let us know](/help/troubleshooting). 
 
 
 ## Saving a filtered view
@@ -225,7 +225,7 @@ The property impacted by the issue, and whether it is documented to be sent with
 - If the property is present in your tracking plan but not set to be sent with your event, you can add it to the event definition.
 - If the property is missing from your tracking plan, you can add it to your tracking plan.
 
-> 💡 Not all issues are related to properties. See [full list of issue types here](https://www.avo.app/docs/explore-tracking-plan/issue-types-in-inspector).
+> 💡 Not all issues are related to properties. See [full list of issue types here](/explore-tracking-plan/issue-types-in-inspector).
 
 <center>
   <img
@@ -256,16 +256,16 @@ If the implementation is not what it should be according to the tracking plan, w
 If the tracking plan is not representing how the event should be, and the implementation is correct, we recommend updating the tracking plan accordingly. In the issue details, you can add events and properties with a click of a button and view the tracking plan definition in the context you are in
 
 
-> 💡 We are very excited about streamlining the process of fixing issues and are going to be working on that soon. Please [reach out](https://www.avo.app/docs/help/troubleshooting) if you have any thoughts on how you would like to act on issues and what would make your team more efficient
+> 💡 We are very excited about streamlining the process of fixing issues and are going to be working on that soon. Please [reach out](/help/troubleshooting) if you have any thoughts on how you would like to act on issues and what would make your team more efficient
 
 ## Why are there no issues in my issues view?
 There can be a few reasons for no issues appearing in your issues view at all or for a specific source.
 
 ### Inspector not installed on source
-The most obvious reason is that you have not yet installed Inspector at all, or on the source that you are looking for. To fix that, [install Inspector](https://www.avo.app/docs/data-design/start-using-inspector#how-to-send-metadata-to-the-inspector) on the source you'd like to see issues for. 
+The most obvious reason is that you have not yet installed Inspector at all, or on the source that you are looking for. To fix that, [install Inspector](/data-design/start-using-inspector#how-to-send-metadata-to-the-inspector) on the source you'd like to see issues for. 
 
 ### Inspector not installed on production
-The issues view currently only displays issues from the past 24 hours in production. That means that if you don't have Inspector installed on production on any source, you won't see any issues in the issues view. To fix that, [install Inspector](https://www.avo.app/docs/data-design/start-using-inspector#how-to-send-metadata-to-the-inspector) on production for the source you'd like to see issues for. 
+The issues view currently only displays issues from the past 24 hours in production. That means that if you don't have Inspector installed on production on any source, you won't see any issues in the issues view. To fix that, [install Inspector](/data-design/start-using-inspector#how-to-send-metadata-to-the-inspector) on production for the source you'd like to see issues for. 
 
 ### No issues in production for the past 24 hours
 The issues view currently only displays issues from the past 24 hours in production. That means that if you don't have any issues in the past 24 hours, then you won't see any issues. Yay!

--- a/pages/reference/avo-codegen/programming-languages/csharp.mdx
+++ b/pages/reference/avo-codegen/programming-languages/csharp.mdx
@@ -119,7 +119,7 @@ interface IDestination {
 }
 ```
 
-If you are using `.NET` source each callback gets an additional first parameter - `userId` and, optionally, a `anonymousId` parameter. To add the optional `anonymousId` parameter to the callbacks in your workspace [reach out to us](https://www.avo.app/docs/help/troubleshooting).
+If you are using `.NET` source each callback gets an additional first parameter - `userId` and, optionally, a `anonymousId` parameter. To add the optional `anonymousId` parameter to the callbacks in your workspace [reach out to us](/help/troubleshooting).
 
 `strict: Boolean`: bool, if true, Avo will throw an exception when it detects a tracking problem in development or staging. Note that the strict flag is ignored in production.
 

--- a/pages/reference/avo-codegen/programming-languages/java.mdx
+++ b/pages/reference/avo-codegen/programming-languages/java.mdx
@@ -124,7 +124,7 @@ public interface ICustomDestination {
 }
 ```
 
-If you are using server Java each callback gets an additional first parameter - `userId` and, optionally, a `anonymousId` parameter. To add the optional `anonymousId` parameter to the callbacks in your workspace [reach out to us](https://www.avo.app/docs/help/troubleshooting).
+If you are using server Java each callback gets an additional first parameter - `userId` and, optionally, a `anonymousId` parameter. To add the optional `anonymousId` parameter to the callbacks in your workspace [reach out to us](/help/troubleshooting).
 
 `boolean strict = true`: bool, if true, Avo will throw an exception when it detects a tracking problem in development or staging environments. Note that the strict flag is ignored in production.
 

--- a/pages/reference/avo-codegen/programming-languages/javascript.mdx
+++ b/pages/reference/avo-codegen/programming-languages/javascript.mdx
@@ -127,7 +127,7 @@ When you define system properties in your Avo workspace you set name and type - 
 };
 ```
 
-In Node each callback is asynchronous and gets an additional first parameter - `userId` and, optionally, a `anonymousId` parameter. To get the `anonymousId` parameter in your workspace [reach out to us](https://www.avo.app/docs/help/troubleshooting).
+In Node each callback is asynchronous and gets an additional first parameter - `userId` and, optionally, a `anonymousId` parameter. To get the `anonymousId` parameter in your workspace [reach out to us](/help/troubleshooting).
 
 `destinationOptions`: send an empty object if you are using the destination interface. If you are using legacy managed destinations here you can pass initialization parameters. `{[segmentDestinationName], [anotherSegmentDestinationName], [amplitudeDestinationName], [mixpanelDestinationName]}`. Keys of this objects are the camelCase versions of your destinations in the Avo UI.
 

--- a/pages/reference/avo-codegen/programming-languages/php.mdx
+++ b/pages/reference/avo-codegen/programming-languages/php.mdx
@@ -139,7 +139,7 @@ class CustomDestination {
 }
 ```
 
-To add the optional `anonymousId` parameter to the callbacks in your workspace [reach out to us](https://www.avo.app/docs/help/troubleshooting).
+To add the optional `anonymousId` parameter to the callbacks in your workspace [reach out to us](/help/troubleshooting).
 
 Read more about the destination interface <Link passHref href="/implementation/destinations">here</Link>.
 

--- a/pages/reference/avo-codegen/programming-languages/python.mdx
+++ b/pages/reference/avo-codegen/programming-languages/python.mdx
@@ -137,7 +137,7 @@ class CustomDestination(object):
 
 > Learn more about group analytics <Link passHref href="/data-design/groups">here</Link>
 
-To add the optional `anonymousId` parameter to the callbacks in your workspace [reach out to us](https://www.avo.app/docs/help/troubleshooting).
+To add the optional `anonymousId` parameter to the callbacks in your workspace [reach out to us](/help/troubleshooting).
 
 ##### Segment example (without the group analytics)
 

--- a/pages/reference/avo-codegen/programming-languages/reasonml.mdx
+++ b/pages/reference/avo-codegen/programming-languages/reasonml.mdx
@@ -126,7 +126,7 @@ This method will call the `make(env, apiKey)` callback in all the provided <Link
 };
 ```
 
-In Node each callback gets an additional first parameter - `userId` and, optionally, a `anonymousId` parameter. To get the `anonymousId` parameter in your workspace [reach out to us](https://www.avo.app/docs/help/troubleshooting).
+In Node each callback gets an additional first parameter - `userId` and, optionally, a `anonymousId` parameter. To get the `anonymousId` parameter in your workspace [reach out to us](/help/troubleshooting).
 
 #### Destination interface example
 

--- a/pages/reference/avo-codegen/programming-languages/rescript.mdx
+++ b/pages/reference/avo-codegen/programming-languages/rescript.mdx
@@ -130,7 +130,7 @@ Custom destination interface format:
 };
 ```
 
-In Node each callback gets an additional first parameter - `userId` and, optionally, a `anonymousId` parameter. To get the `anonymousId` parameter in your workspace [reach out to us](https://www.avo.app/docs/help/troubleshooting).
+In Node each callback gets an additional first parameter - `userId` and, optionally, a `anonymousId` parameter. To get the `anonymousId` parameter in your workspace [reach out to us](/help/troubleshooting).
 
 #### Destination interface example
 

--- a/pages/reference/avo-codegen/programming-languages/ruby.mdx
+++ b/pages/reference/avo-codegen/programming-languages/ruby.mdx
@@ -121,7 +121,7 @@ end
 
 ```
 
-To add the optional `anonymousId` parameter to the callbacks in your workspace [reach out to us](https://www.avo.app/docs/help/troubleshooting).
+To add the optional `anonymousId` parameter to the callbacks in your workspace [reach out to us](/help/troubleshooting).
 
 Read more about the destination interface <Link passHref href="/implementation/destinations">here</Link>.
 

--- a/pages/reference/avo-codegen/programming-languages/typescript.mdx
+++ b/pages/reference/avo-codegen/programming-languages/typescript.mdx
@@ -147,7 +147,7 @@ Custom destination interface format:
 };
 ```
 
-In Node each callback is asynchronous and gets an additional first parameter - `userId` and, optionally, a `anonymousId` parameter. To get the `anonymousId` parameter in your workspace [reach out to us](https://www.avo.app/docs/help/troubleshooting).
+In Node each callback is asynchronous and gets an additional first parameter - `userId` and, optionally, a `anonymousId` parameter. To get the `anonymousId` parameter in your workspace [reach out to us](/help/troubleshooting).
 
 #### Destination interface example: Mixpanel
 

--- a/pages/reference/avo-debuggers/overview.mdx
+++ b/pages/reference/avo-debuggers/overview.mdx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-
 # Setup Avo Visual Debugger in code
 
 When implementing analytics on web and mobile apps it’s hard to know if the events are being sent successfully or not, and if they are being sent at the correct time.
@@ -12,8 +10,8 @@ Each Avo function will automatically show events in the debugger with timestamp 
 
 If Avo detects errors the visual debugger will highlight those.
 
-> Debuggers are disabled in the <Link passHref href="/implementation/avo-and-unit-tests">noop</Link> mode
+> Debuggers are disabled in the [noop](/implementation/avo-and-unit-tests) mode
 
-### <Link passHref href="/implementation/start-using-web-debugger">Web debugger</Link>   
+### [Web debugger](/implementation/start-using-web-debugger)
 
-### <Link passHref href="/implementation/setup-mobile-debugger">Mobile debuggers</Link>
+### [Mobile debuggers](/implementation/setup-mobile-debugger)

--- a/pages/reference/avo-debuggers/web.mdx
+++ b/pages/reference/avo-debuggers/web.mdx
@@ -1,14 +1,12 @@
-import Link from 'next/link';
-
 # Start using Avo Visual Debugger in code
 
-Currently the web visual debugger is only available when you use <Link passHref href="/implementation/avo-codegen-overview">Avo Codegen</Link>.
+Currently the web visual debugger is only available when you use [Avo Codegen](/implementation/avo-codegen-overview).
 
 Each Avo function will automatically show events in the debugger with timestamp and all the properties.
 
 If Avo detects errors the visual debugger will highlight those.
 
-> Debuggers are disabled in the <Link passHref href="/implementation/avo-and-unit-tests">noop</Link> mode
+> Debuggers are disabled in the [noop](/implementation/avo-and-unit-tests) mode
 
 ### Accessing the web debugger
 

--- a/pages/reference/avo-inspector-sdks/overview.mdx
+++ b/pages/reference/avo-inspector-sdks/overview.mdx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { Callout } from 'nextra/components'
 
 # Avo Inspector SDKs
@@ -6,15 +5,6 @@ import { Callout } from 'nextra/components'
 Avo Inspector analyzes the analytics events sent from your app, without collecting the actual data (not yet another tool to add to your privacy policy). Based on that analysis Avo automatically builds a single source of truth tracking plan, covering all your products and platforms, giving you a complete overview of which is tracking what, and which is not.
 
 Avo Inspector SDK is designed to be small and easy to include in any project.
-
-**Table of Contents**
-
-- [Platform documentation](#platform-docs)
-- [Usage overview](#standalone-usage)
-- [Supported event schema types](#supported-types)
-- [Batching](#batching)
-- [Easy setup with Segment SDK on Android and iOS](#segment-middleware)
-  
 
 ## Platform documentation
 
@@ -29,11 +19,11 @@ Avo Inspector SDK is designed to be small and easy to include in any project.
 
 ## Usage overview
 
-Find in <Link passHref href="/implementation/avo-inspector-overview">Avo Inspector overview</Link> guide.
+Find in [Avo Inspector overview](/implementation/avo-inspector-overview) guide.
 
 ## Logs
 
-You can enable or disable logs with a method on the `AvoInspector` class (the interface may vary depending on platform, see <a href="#platform-docs">platform specific documentation</a> above)
+You can enable or disable logs with a method on the `AvoInspector` class (the interface may vary depending on platform, see [platform specific documentation](#platform-docs) above)
 
 `AvoInspector.enableLogging(isEnabled)`
 


### PR DESCRIPTION
Looks like I had wrapped some links with quotes (like you'd do in jsx-land) but the quotes actually ended up as part of the url which ruined them. Also includes some `<Link>` → `[]()` conversions and removing full-urls to docs pages to get the SPA routing benefits.