### PR TITLE
Rewrite old workspace links to avoid a reload and re-direct

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -6,12 +6,9 @@
 Callout
 nextra
 quickstart
-avo
 validateAvoEvent
 PMs
 codemods
-40
-90
 analytics.js
 analytics
 codebase
@@ -28,11 +25,8 @@ img
 src
 gif
 png
-collaborators.gif
 passHref
 href
-cli#step-4-monitor-the-analytics-implementation
-implement#a-nameimplement-actionsa-implement-events
 avo.json
 config
 codegen
@@ -40,7 +34,6 @@ Signup
 boolean
 Num
 UTM
-properties#a-nameproperty-types-and-constraintsa-property-types-and-constraints
 FB
 KPI
 granularly
@@ -50,15 +43,9 @@ Stef
 cofounder
 onboard
 namespace
-already_exists.png
-consistant_casing.png
-similar_to.png
 codebases
-tracking_plan_validation.png
 a.k.a.
 onboarding
-category_example.png
-comment.png
 edit-collaborators-ui
 schemas
 webhook
@@ -127,7 +114,6 @@ subdocs
 signup
 backend
 init_avo
-connections.png
 logEvent
 podfile
 build.gradle
@@ -136,10 +122,7 @@ package.json
 macOS
 xamarin
 clojure
-review_branch.gif
 backends
-accessMembers.png
-protectedMainBranch.png
 fullstory
 uncheck
 JVM
@@ -219,12 +202,9 @@ Json
 Iglu
 eventSchemas
 contextSchemas
-property_enum_source_specific.png
 hardcoded
 hardcode
-request_branch_review.png
 dropdown
-archive.png
 unarchive
 sourceIds
 imageUrl
@@ -239,19 +219,11 @@ v3.2.0
 coroutines
 KotlinCoroutines
 devs-101
-integrations#slack
-implementation-status#inspector-implementation-status
-avo-functions-overview#whats-happening-inside-the-avo-functions
 avo-in-the-ci
-implementation-status#avo-functions-implementation-status
 AvoInspectorEnv.Dev
 AvoInspectorEnv.Staging
 AvoInspectorEnv.Prod
 PostHog
-events#a-nameidentify-usera-identify-user
-avo-codegen-overview#whats-happening-inside-the-avo-codegen
-implementation-status#avo-codegen-implementation-status
-define-sources-and-destinations#destinations
 PII
 FreshPaint
 unidentifies
@@ -275,16 +247,6 @@ RudderStack
 Pendo
 Jira
 CocoaPods
-server-gtm-templates
-server-gtm-template-new
-server-gtm-import
-server-gtm-tags
-server-gtm-tag-new
-server-gtm-tag-configuration
-server-gtm-avo-inspector-setup
-guide-posthog-to-inspector
-insert-api-key
-logs.png
 i.e.
 rudderstack-transformation-test
 completedd
@@ -312,9 +274,6 @@ people.track_charge
 7d
 timewindow
 avo.initavo
-property_presence_per_event.png
-property_presence_per_source_and_event.png
-property_enum.png
 Pseudocodegen
 tripple-dot
 name_mapping_per_event.mp4
@@ -382,18 +341,6 @@ CustomDestination
 reportFailureAs
 myapp.com
 TwoCol
- - pages/data-design/defining-descriptive-events-and-properties.mdx
-facebook
- - pages/explore-tracking-plan/issue-types-in-inspector.mdx
-_
-Completedd
-authenticationMethod
- - pages/implementation/avo-inspector-sdk-reference.mdx
-0f5d04ddbb401971b2f9c7f6186f58161692c3d8
-prod.commit.b401971
- - pages/audit/quickstart.mdx
-audit.png
- - pages/audit/rules.mdx
 app_opened
 add_to_cart
 checkoutStarted
@@ -403,263 +350,30 @@ user_id
 email_adddress
 email_address
 product_name
- - pages/data-design/multiple-sources-on-avo-branches.mdx
-_If_
-tripple-dot
-jira
-popup
-Solvi
-Stefania
-deeplinks
-checkbox
-bool
-setAvoLogger
-setSystemProperties
-FacebookAnalytics
-Permutive
-ZendeskConnect
-Apptelemetry
-RudderStack
-Freshpaint
-Posthog
-Kissmetrics
-LaunchDarkly
-Pendo
-Fivetran
-setUserId
-logRevenue
-logRevenueV2
-enums
-7d
-timewindow
-csv
-Avo.initAvo
-property_presence_per_event.png
-property_presence_per_source_and_event.png
-property_enum.png
-publishing.svg
-200px
-auto_publishing.png
-publish_filter.png
-publishing_protocols.svg
-publishing_lexicon.svg
-publishing_govern.svg
-i.e.
-erroring
-publishing_webhook.svg
-metricId
-sourceId
-destinationId
-categoryId
-publishInfo
-PublishInfo
-PropertyRules
-PropertyRule
-EventSegmentation
-eventId
-whereFilter
-groupBy
-groupByFilter
-propertyId
-programmingLanguage
-developmentplatform
-branchid
-branchname
-integrationid
-integrationname
-publishdate
-publishmethod
-branchmerge
-jitpack.io
-logcat
-nullable
-debuggermanager
-avoinspector
-cocoapods
-nsdictionary
-analyticsdebugger
-propname
-camelCase
- - pages/workspace/integrations.mdx
-350px
- - pages/implementation/reference/javascript.mdx
-GroupId
-companyGroupId
- - pages/workspace/tracking-plan/events.mdx
-track_charge
-people.track_charge
-logEventWithGroups
-track_with_groups
-setGroup
-set_group
-groupIdentify
-group.set
- - pages/implementation/reference/java.mdx
-signup-start-ui
- - pages/implementation/reference/csharp.mdx
- - pages/implementation/reference/php.mdx
-customDestinationInstance
- - pages/implementation/reference/csharp.mdx
-signup-start-ui
- - pages/implementation/reference/reasonml.mdx
-Js.t
-CustomDestination
-AvoEnv
-AvoSystemProperties.t
- - pages/implementation/reference/typescript.mdx
-reportFailureAs
- - pages/data-design/day-to-day-workflow.mdx
-autoPlay
-mp4
-collaborators.mp4
-Jira
- - pages/workspace/branches.mdx
 review_branch.mp4
- - pages/data-design/quick-start.mdx
-450px
-review_branch.mp4
-workbench.png
- - pages/workspace/tracking-plan/properties.mdx
-B2B
-key1
-value1
-key2
-value2
- - pages/data-design/name-mapping.mdx
 name_mapping_per_event.mp4
- - pages/implementation/read-implementation-diff.mdx
 add_spi
 seat_prompt_interact
- - pages/data-design/define-sources-and-destinations.mdx
 MacOS
 Node.JS
- - pages/implementation/destinations.mdx
-javascript#destination-interface-example
-typescript#destination-interface-example
-rescript#destination-interface-example
-reasonml#destination-interface-example
-objc#destination-interface-example
-swift#destination-interface-example
-java#destination-interface-example
-kotlin#destination-interface-example
-php#destination-interface-example
-python#destination-interface-example
-ruby#destination-interface-example
-csharp#destination-interface-example
- - pages/implementation/devs-101.mdx
-mParticle
-setUserProperties
-PII
-RudderStack
-PostHog
- - pages/workspace/tracking-plan/publishing.mdx
-publishing_mparticle.svg
-publishing_rudderstack.svg
-publishing_snowplow.svg
- - pages/workspace/connect-inspector-to-rudderstack.mdx
-rudderstack-transformation-test
-SnowflakeDB
-BigQuery
-dbt
-yml
- - pages/workspace/tracking-plan/importing.mdx
-b2b
-troubleshooting#contact-us
- - pages/workspace/connect-inspector-to-posthog.mdx
-PostHog
-guide-posthog-to-inspector
-insert-api-key
-logs.png
- - pages/audit/branch-audit.mdx
-add_to_cart
- - pages/workspace/tracking-plan/webhook-signing.mdx
-600px
-HMAC
-SHA-256
-Jwt
-iat
-request.body
+Asana
  - pages/workflow/review.mdx
 _Role
 2.review
-Asana
  - pages/workflow/implement.mdx
-RudderStack
-index.module.scss
-PageLink
-CallToAction
-AnalyticsManagerIcon
-svg
-analyticsmanager.svg
-DevIcon
-styles.css
- - pages/workflow/plan.mdx
 1.plan
-event.png
 cmd
 ctrl
- - pages/workflow/request-implementation.mdx
-3.request
-306px
- - pages/workflow/validate.mdx
-5.validate
-pill.png
-implementatin
- - pages/public-api/overview.mdx
-versioned
- - pages/public-api/authentication.mdx
-Base64
-public-api
  - pages/implementation/cli.mdx
 forceFeatures
- - pages/public-api/export-tracking-plan.mdx
-workspaceId
-base64
- - pages/workspace/add-events-from-inspector.mdx
-dashboard.png
- - pages/workspace/code-changes.mdx
 REACTION_REMOVED
-app_id
-bot_id
-nodiff-snippet
-Pseudocodegen
-prepended
- - pages/publishing/mparticle-data-master.mdx
-publishing_mparticle.svg
- - pages/publishing/publishing-use-cases.mdx
-SnowflakeDB
-BigQuery
-dbt
-yml
- - pages/publishing/rudderstack.mdx
-publishing_rudderstack.svg
- - pages/publishing/snowplow-data-structures.mdx
-publishing_snowplow.svg
- - pages/publishing/mixpanel-lexicon.mdx
-prepended
-306px
-shared.png
-share.png
- - pages/workspace/connect-inspector-to-gtm.mdx
-server-gtm-download
-server-gtm-templates
-server-gtm-template-new
-server-gtm-import
-server-gtm-tags
-server-gtm-tag-new
-server-gtm-tag-configuration
-server-gtm-avo-inspector-setup
  - pages/index.mdx
 analyticsmanager.svg
-avo-inspector-sdk-reference
  - pages/legacy-migrating-to-avo.mdx
 validateAvoEven
  - pages/inspector/connect-inspector-to-gtm.mdx
-server-gtm-download
- - pages/data-design/best-practices/defining-descriptive-events-and-properties.mdx
 facebook
  - pages/data-design/branches/code-changes.mdx
-200px
 REACTION_REMOVED
 app_id
 bot_id

--- a/next.config.js
+++ b/next.config.js
@@ -34,7 +34,7 @@ const redirects = [
   },
   {
     source: '/datascope/state-of-tracking',
-    destination: '/workspace/inspector',
+    destination: '/inspector/start-using-inspector',
     permanent: true,
   },
   {
@@ -54,12 +54,12 @@ const redirects = [
   },
   {
     source: '/datascope',
-    destination: '/workspace/inspector',
+    destination: '/inspector/start-using-inspector',
     permanent: true,
   },
   {
     source: '/datascope/avo-inspector',
-    destination: '/workspace/inspector',
+    destination: '/inspector/start-using-inspector',
     permanent: true,
   },
   {
@@ -79,7 +79,7 @@ const redirects = [
   },
   {
     source: '/datascope/issue-identifier',
-    destination: '/workspace/inspector',
+    destination: '/inspector/start-using-inspector',
     permanent: true,
   },
   {
@@ -319,12 +319,12 @@ const redirects = [
   },
   {
     source: '/workspace/publishing',
-    destination: '/workspace/tracking-plan/publishing',
+    destination: '/publishing/publishing/overview',
     permanent: true,
   },
   {
     source: '/workspace/publishing/',
-    destination: '/workspace/tracking-plan/publishing',
+    destination: '/publishing/publishing/overview',
     permanent: true,
   },
   {
@@ -359,12 +359,12 @@ const redirects = [
   },
   {
     source: '/data-design/import-tracking-plan/',
-    destination: '/workspace/tracking-plan/importing',
+    destination: '/publishing/importing',
     permanent: true,
   },
   {
     source: '/data-design/import-tracking-plan',
-    destination: '/workspace/tracking-plan/importing',
+    destination: '/publishing/importing',
     permanent: true,
   },
   {
@@ -403,12 +403,12 @@ const redirects = [
   },
   {
     source: '/data-design/start-publishing/',
-    destination: '/workspace/tracking-plan/publishing',
+    destination: '/publishing/publishing/overview',
     permanent: true,
   },
   {
     source: '/data-design/start-publishing',
-    destination: '/workspace/tracking-plan/publishing',
+    destination: '/publishing/publishing/overview',
     permanent: true,
   },
   {

--- a/pages/audit/branch-audit.mdx
+++ b/pages/audit/branch-audit.mdx
@@ -8,7 +8,7 @@ _Learn how to use branch audits to identify and resolve issues introduced on bra
 
 The branch audit reviews the changes you have made on your branch and flags issues which are introduced by your changes, such as unexpected naming or inconsistent types — helping you keep your tracking plan clean and consistent.
 
-When [reviewing changes on a branch](/workspace/branches#review-branch-changes), you can see issues directly on your tracking plan items and in the instance of inconsistent casing you can automatically fix the issue by the click of a button.
+When [reviewing changes on a branch](/data-design/branches#review-branch-changes), you can see issues directly on your tracking plan items and in the instance of inconsistent casing you can automatically fix the issue by the click of a button.
 
 ![Example of an inline audit in the diff screen showing changes to an event called add_to_cart. The audit suggests there are two issues: the event name is not consistent with the naming convention and it doesn't have a description.](/images/audit/inline-audit.png)
 
@@ -28,8 +28,8 @@ For Enterprise plans you have the possibility of enforcing that there are no iss
 
 To learn more about the audit rules, see [Avo's tracking plan audit rules](/audit/rules).
 
-<Callout>The branch audit only audits the _branch_. If you want to identify issues in the tracking plan check out the [Tracking Plan Audit](/audit/overview). If you want to identify issues in your current tracking implementation and data streams, check out [Tracking Observability](/workspace/inspector).</Callout>
+<Callout>The branch audit only audits the _branch_. If you want to identify issues in the tracking plan check out the [Tracking Plan Audit](/audit/overview). If you want to identify issues in your current tracking implementation and data streams, check out [Tracking Observability](/inspector/inspector-overview).</Callout>
 
 ## What's next?
 
-Follow the [quickstart guide](/workspace/branches) to start a branched workflow in Avo and see how you can get a review of your changes on the branch in 5 minutes.
+Follow the [quickstart guide](/data-design/branches) to start a branched workflow in Avo and see how you can get a review of your changes on the branch in 5 minutes.

--- a/pages/audit/overview.mdx
+++ b/pages/audit/overview.mdx
@@ -12,7 +12,7 @@ Furthermore, all changes on branches are also checked in the [Branch Audit](/aud
 
 To learn more about the audit rules, see [Avo's tracking plan audit rules](/audit/rules).
 
-<Callout>The tracking plan audit only audits the _plan_. If you want to identify issues in your current tracking implementation and data streams, check out [Tracking Observability](/workspace/inspector).</Callout>
+<Callout>The tracking plan audit only audits the _plan_. If you want to identify issues in your current tracking implementation and data streams, check out [Tracking Observability](/inspector/inspector-overview).</Callout>
 
 ## What's next?
 

--- a/pages/audit/quickstart.mdx
+++ b/pages/audit/quickstart.mdx
@@ -17,7 +17,7 @@ If you have a tracking plan defined in a Excel or Google Sheet spreadsheet, or i
 ![](/images/audit/import-button.png)
 
 To learn more about importing your existing tracking plan to Avo, see the
-[importing your tracking plan](/workspace/tracking-plan/importing) guide.
+[importing your tracking plan](/publishing/importing) guide.
 
 ### Step 3: Review the tracking plan audit
 
@@ -29,4 +29,4 @@ To learn more about how to review your tracking plan audit, and how to resolve i
 
 ## What's next?
 
-Open a branch in Avo and start suggesting changes to resolve your top priority issues. To learn more about branches see [Branches](/workspace/branches) and to learn more about how to resolve the audit issues see the [Audit rules](/audit/rules).
+Open a branch in Avo and start suggesting changes to resolve your top priority issues. To learn more about branches see [Branches](/data-design/branches) and to learn more about how to resolve the audit issues see the [Audit rules](/audit/rules).

--- a/pages/data-design/avo-tracking-plan/events.mdx
+++ b/pages/data-design/avo-tracking-plan/events.mdx
@@ -19,12 +19,12 @@ An event is defined in the Events section of the Tracking plan and can be organi
  with information about the event beyond what the name includes (optional but highly recommended)
 - The [_Trigger(s)_](/data-design/event-triggers)
  that describe both visually and in words all the user or system actions that trigger the event (optional but highly recommended)
-- The [_Source(s)_](/workspace/connections#a-namesourcesa-sources-where-the-data-comes-from)
+- The [_Source(s)_](/data-design/define-sources-and-destinations#sources-where-the-data-comes-from)
  that the event should be sent from
 - The [_Actions(s)_](#actions) associated with the event
-- The [_Metrics(s)_](/workspace/tracking-plan/metrics)
+- The [_Metrics(s)_](/data-design/avo-tracking-plan/metrics)
  related to the event (optional)
-- The [_Category(s)_](/data-design/organizing-metrics-and-events#a-namecategoriesa-categories)
+- The [_Category(s)_](/data-design/organizing-metrics-and-events#categories)
  that the event is a part of (optional)
 - The _Tags_ associated with the event
 - The [_Name Mapping(s)_](/data-design/name-mapping)
@@ -40,7 +40,7 @@ Add all sources you want the event to be sent from to the event in Avo. If you w
 
 Actions is Avo's umbrella term over all the tracking methods the analytics platforms offer, such as logging events, updating user properties, logging revenue, etc. In your Avo tracking plan you can configure which actions (tracking methods) should be triggered. Actions can be triggered on their own or together, for example it's common to update user properties along with logging an event.
 
-See [supported actions (tracking methods)](/workspace/tracking-plan/events#supported-actions)
+See [supported actions (tracking methods)](/data-design/avo-tracking-plan/events#supported-actions)
  below.
 
 ### Configuring Actions

--- a/pages/data-design/avo-tracking-plan/index.mdx
+++ b/pages/data-design/avo-tracking-plan/index.mdx
@@ -6,21 +6,19 @@ code from and validate your data against.
 
 The following sections build up your Avo workspace:
 
-- [Tracking Plan Events](/workspace/tracking-plan/events): where all events structures are defined
+- [Tracking Plan Events](/data-design/avo-tracking-plan/events): where all events structures are defined
 
-- [Tracking Plan Properties](/workspace/tracking-plan/properties): where all properties are defined
+- [Tracking Plan Properties](/data-design/avo-tracking-plan/properties): where all properties are defined
 
-- [Tracking Plan Metrics](/workspace/tracking-plan/metrics): where all metrics are defined
+- [Tracking Plan Metrics](/data-design/avo-tracking-plan/metrics): where all metrics are defined
 
-- [Tracking Plan Publishing](/workspace/tracking-plan/publishing): sync your tracking plan with the one in your analytics platform
+- [Tracking Plan Publishing](/publishing/publishing/overview): sync your tracking plan with the one in your analytics platform
 
-- [Connection Setup](/workspace/connections): configure sources and destinations, including setting up Inspector and Avo Codegen
+- [Connection Setup](/data-design/define-sources-and-destinations): configure sources and destinations, including setting up Inspector and Avo Codegen
 
-- [Codegen Reference](/workspace/implement): source specific event reference for Avo Codegen, with code snippets that help
-  you implement
+- [Codegen Setup](/implementation/start-using-avo-codegen): source specific event reference for Avo Codegen, with code snippets that help you implement
 
-- [Inspector](/workspace/inspector): get a report of the state of your tracking and get alerted when new issues are
-  detected
+- [Inspector](/inspector/inspector-overview): get a report of the state of your tracking and get alerted when new issues are detected
 
 ![Example tracking plan in Avo](/images/workspace/nav-tracking-plan.png)
 

--- a/pages/data-design/avo-tracking-plan/properties.mdx
+++ b/pages/data-design/avo-tracking-plan/properties.mdx
@@ -8,15 +8,15 @@ Properties are also known as traits, attributes, metadata, etc. They are informa
 
 ## Property Definition
 
-A property is defined in the event details within the relevant [actions](/workspace/tracking-plan/events#a-nameactionsa-actions) or in the properties view.
+A property is defined in the event details within the relevant [actions](/data-design/avo-tracking-plan/events#actions) or in the properties view.
 
 - A descriptive [Property Name](/data-design/defining-descriptive-events-and-properties#properties)
 - A [Description](/data-design/defining-descriptive-events-and-properties#properties-1) that gives additional context of what the property is describing beyond the property name (optional but highly recommended)
-- The [property value type](/workspace/tracking-plan/properties#a-nameproperty-types-and-constraintsa-property-types-and-constraints) (required)
+- The [property value type](/data-design/avo-tracking-plan/properties#property-types-and-constraints) (required)
 
-- The [events](/workspace/tracking-plan/events) that the property is attached to (required)
-- The [presence](/workspace/tracking-plan/properties#a-nameproperty-presence-configurationa-configuring-when-properties-are-required-or-optional) of the property on each event – whether it's required or optional (required)
-- The [constraints](/workspace/tracking-plan/properties#a-nameproperty-types-and-constraintsa-property-types-and-constraints) defined for the property values (optional but highly recommended)
+- The [events](/data-design/avo-tracking-plan/events) that the property is attached to (required)
+- The [presence](/data-design/avo-tracking-plan/properties#configuring-when-properties-are-required-or-optional) of the property on each event – whether it's required or optional (required)
+- The [constraints](/data-design/avo-tracking-plan/properties#property-types-and-constraints) defined for the property values (optional but highly recommended)
 - The [name mappings](/data-design/name-mapping) the property name is mapped to when sending to specific destinations (optional)
 
 ## Event properties
@@ -31,7 +31,7 @@ relevant for that specific event, when you analyze your data. You might be want 
 
 **Functionality**
 
-Event properties are sent with the event in the [event call](/workspace/tracking-plan/events#a-namelog-eventa-log-event).
+Event properties are sent with the event in the [event call](/data-design/avo-tracking-plan/events#log-event).
 
 ## Group properties
 
@@ -52,7 +52,7 @@ In that case, you can maintain the state of each company with group properties, 
 
 **Functionality**
 
-Group properties are updated with the event in the [Update Groups](/workspace/tracking-plan/events#update-groups) action.
+Group properties are updated with the event in the [Update Groups](/data-design/avo-tracking-plan/events#update-groups) action.
 
 ### Managing Groups
 
@@ -108,7 +108,7 @@ along with your events when they actually change.
 
 **Functionality**
 
-User properties are updated with the [Update User Properties](/workspace/tracking-plan-actionvents#a-nameupdate-user-propsa-update-user-properties).
+User properties are updated with the [Update User Properties](/data-design/avo-tracking-plan/events#update-user-properties).
 
 ## System properties
 

--- a/pages/data-design/avo-tracking-plan/workbench.mdx
+++ b/pages/data-design/avo-tracking-plan/workbench.mdx
@@ -4,7 +4,7 @@
 
 ### What is the Workbench?
 
-In Avo you can collaborate in real time on defining, expanding and implementing your tracking plan. Using [Branches](/workspace/branches) helps you make your changes without disrupting your main source of truth with the power of approvals.
+In Avo you can collaborate in real time on defining, expanding and implementing your tracking plan. Using [Branches](/data-design/branches) helps you make your changes without disrupting your main source of truth with the power of approvals.
 
 If you are already on a branch, all changes will be captured in the [Review screen](/workflow/review) but the Events screen has a handy little summary at the top called the **Workbench** where you can have an overview of the changes you've made on your branch.
 
@@ -16,8 +16,8 @@ Events that are being changed or added will populate the Workbench as you go wit
 
 ## What's next?
 
-- [Approval workflows for branches](/workspace/approval-workflows)
-- [Share implementation instructions for a branch](/workspace/code-changes)
+- [Approval workflows for branches](/data-design/branches/approval-workflows)
+- [Share implementation instructions for a branch](/data-design/branches/code-changes)
 - [Using Avo in parallel workflows for large development teams](/implementation/avo-and-git)
 - [How to manage branches with multiple sources](/data-design/multiple-sources-on-avo-branches)
 - [Designing data in Avo](/data-design/start-data-design)

--- a/pages/data-design/best-practices/defining-descriptive-events-and-properties.mdx
+++ b/pages/data-design/best-practices/defining-descriptive-events-and-properties.mdx
@@ -86,7 +86,7 @@ Events and properties with a descriptive name get you far to create a common und
 
 ### Events
 
-For [events](/workspace/tracking-plan/events#a-nameevent-defintiona-event-definition) we recommend adding a description to an event with all the information required for a developers to trigger an event by the same user action for all code paths, platforms and products.
+For [events](/data-design/avo-tracking-plan/events#event-definition) we recommend adding a description to an event with all the information required for a developers to trigger an event by the same user action for all code paths, platforms and products.
 
 For example for the "Purchase completed" a good description would be: _Event sent when the client receives a successful response when a user has completed a purchase._
 
@@ -100,7 +100,7 @@ For example for a "Search Result Position" property on a "Search Result Clicked"
 
 ## Property constraints
 
-[Property constraints](/workspace/tracking-plan/properties#a-nameproperty-types-and-constraintsa-property-types-and-constraints) are very useful to ensure that the correct spelling or allowed numerical
+[Property constraints](/data-design/avo-tracking-plan/properties#property-types-and-constraints) are very useful to ensure that the correct spelling or allowed numerical
 values are sent with the event.
 
 We recommend using property constraints whenever possible, specifically in cases when:

--- a/pages/data-design/best-practices/groups.mdx
+++ b/pages/data-design/best-practices/groups.mdx
@@ -5,7 +5,7 @@ import {Callout} from 'nextra/components'
 <Callout>**Group analytics** is a terminology used in product analytics tools, that 
 refers to grouping by unique product concepts other than unique users.</Callout>
 
-The concept of [grouping product analytics by unique _users_](/workspace/tracking-plan/properties#user-properties)
+The concept of [grouping product analytics by unique _users_](/data-design/avo-tracking-plan/properties#user-properties)
 is well established. E.g. counting unique users who perform specific actions in your product, 
 or individual user retention. In addition to unique users, most products have other core concepts 
 to group by, such as _unique workspaces_, _unique chat channels_, _unique games_, etc.  

--- a/pages/data-design/best-practices/naming-conventions.mdx
+++ b/pages/data-design/best-practices/naming-conventions.mdx
@@ -110,7 +110,7 @@ In addition to the support that's built into the Avo app, the Avo review workflo
 
 The typical Avo customer has years of tracking in place when they start using Avo (and some analytics debt to pay down...). That is why Avo not only has prescriptive tools in place, but also ones that inspect and detect:
 
-1. The **[Avo issue reporter](/workspace/tracking-plan#a-nametracking-plan-issue-reportera-the-tracking-plan-issue-reporter) reports events that break casing convention** in your tracking plan casing:
+1. The **[Avo issue reporter](/audit/overview) reports events that break casing convention** in your tracking plan casing:
 
    So for example if you upload your current tracking plan in Avo, the issue reporter will highlight naming issues:
 

--- a/pages/data-design/branches/approval-workflows.mdx
+++ b/pages/data-design/branches/approval-workflows.mdx
@@ -4,9 +4,9 @@ _Increase the quality of your tracking plan with protected main branch and branc
 
 Building a tracking plan is a team sport. Getting feedback from your team on the changes you're making to the tracking plan helps with building alignment and keeping the plan consistent. That's why we built approval workflows. Approval workflows can be configured in three ways:
 
-1. [Protected main branch](/workspace/approval-workflows#protected-main-branch)
-2. [Require admin approval](/workspace/approval-workflows#require-admin-approval)
-3. [Require multiple approvals](/workspace/approval-workflows#require-multiple-approvals)
+1. [Protected main branch](/data-design/branches/approval-workflows#protected-main-branch)
+2. [Require admin approval](/data-design/branches/approval-workflows#require-admin-approval)
+3. [Require multiple approvals](/data-design/branches/approval-workflows#require-multiple-approvals)
 
 ### Protected main branch
 

--- a/pages/data-design/branches/index.mdx
+++ b/pages/data-design/branches/index.mdx
@@ -30,7 +30,7 @@ To create a new branch, first make sure you are on the main branch. Then click t
 
 When you've suggested changes to your tracking, mark the branch as ready for review, and @-mention a co-worker to ask them for a review.
 
-We recommend you [connect your Avo workspace to Slack](/workspace/integrations#enable-slack-notifications-in-your-avo-workspace) for added visibility into tracking plan changes your team is making.
+We recommend you connect your Avo workspace to Slack in the workspace settings for added visibility into tracking plan changes your team is making.
 
 ![Request branch review](/images/request_branch_review.png)
 
@@ -72,9 +72,9 @@ Click the Avo logo in the top left of your workspace to navigate to the branches
 
 ## What's next?
 
-- [Approval workflows for branches](/workspace/approval-workflows)
-- [Workbench](/workspace/tracking-plan/workbench)
-- [Share implementation instructions for a branch](/workspace/code-changes)
+- [Approval workflows for branches](/data-design/branches/approval-workflows)
+- [Workbench](/data-design/avo-tracking-plan/workbench)
+- [Share implementation instructions for a branch](/data-design/branches/code-changes)
 - [Using Avo in parallel workflows for large development teams](/implementation/avo-and-git)
 - [How to manage branches with multiple sources](/data-design/multiple-sources-on-avo-branches)
 - [Designing data in Avo](/data-design/start-data-design)

--- a/pages/data-design/define-sources-and-destinations.mdx
+++ b/pages/data-design/define-sources-and-destinations.mdx
@@ -221,4 +221,4 @@ Think "We send the Signup Complete event from web and send it to our Custom Anal
 
 ## What's next?
 
-Now you know how to define and configure sources and destinations in Avo. Next thing to learn is [the branched workflows](/workspace/branches).
+Now you know how to define and configure sources and destinations in Avo. Next thing to learn is [the branched workflows](/data-design/branches).

--- a/pages/data-design/guides/documenting-purpose-meetings-in-avo.mdx
+++ b/pages/data-design/guides/documenting-purpose-meetings-in-avo.mdx
@@ -12,7 +12,7 @@ The outputs of the meeting are:
 
 But how can you document the outcome of this meeting in context with your event definitions in Avo?
 
-We recommend using a combination of [categories and metrics](/data-design/organizing-metrics-and-events#a-namecategoriesa-categories) to do so.
+We recommend using a combination of [categories and metrics](/data-design/organizing-metrics-and-events#categories) to do so.
 
 ## Step 1 – Open a branch in Avo
 

--- a/pages/data-design/guides/implementation-instructions.mdx
+++ b/pages/data-design/guides/implementation-instructions.mdx
@@ -6,7 +6,7 @@ _Share auto-generated implementation instructions with your team in your favorit
 
 <Callout>
   This feature has been deprecated with the new [branch implementation
-  instructions](/workspace/code-changes) that include more details, better
+  instructions](/data-design/branches/code-changes) that include more details, better
   filtering, visual diffing and more.
 </Callout>
 

--- a/pages/data-design/guides/object-properties.mdx
+++ b/pages/data-design/guides/object-properties.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components';
 
 # Defining object properties
 
-In your Avo Tracking Plan properties can have 5 different types, string, integer, float, boolean and object. Learn more about properties in general [in this doc](/workspace/tracking-plan/properties).
+In your Avo Tracking Plan properties can have 5 different types, string, integer, float, boolean and object. Learn more about properties in general [in this doc](/data-design/avo-tracking-plan/properties).
 
 In this guide we'll go through the process of defining an object property, including constraints on its keys and values.
 
@@ -40,4 +40,4 @@ Click the type dropdown in the property drawer and select "object"
 ### What's next?
 
 - [Learn how to pin values of specific object keys in this guide on pinned properties](/data-design/pinned-properties)
-- [Learn more about properties in general](/workspace/tracking-plan/properties)
+- [Learn more about properties in general](/data-design/avo-tracking-plan/properties)

--- a/pages/data-design/guides/reset-tracking-plan.mdx
+++ b/pages/data-design/guides/reset-tracking-plan.mdx
@@ -7,9 +7,8 @@ _You might find yourself in the position where you want to start fresh and resta
 You might find yourself in the position where you want to start fresh and restart your Tracking Plan. This guide covers how to do exactly that.
 
 <Callout emoji="🔒">
-  {' '}
   Note that resetting the Tracking Plan requires Admin privileges. Learn more about
-  roles and permissions in the [members and roles guide](/workspace/members).
+  roles and permissions in the [members and roles guide](/data-design/collaboration/members).
 </Callout>
 
 ### What happens when I reset my Tracking Plan?

--- a/pages/data-design/quick-start.mdx
+++ b/pages/data-design/quick-start.mdx
@@ -6,7 +6,7 @@ Managing a tracking plan is hard. You have to make sure it's kept up to date to 
 
 If you relate to any of the challenges mentioned above you might want to consider switching your tracking plan over to Avo.
 
-The Avo Tracking Plan is a collaborative web app that will make managing your tracking plan less of a headache, with features like [Tracking Plan audit](/audit/overview) to ensure naming conventions are followed, [global event and property namespace](/data-design/global-namespace) to ensure consistency across your events and properties, [branched collaboration](/workspace/branches) with [approval workflows](/workspace/branches#protected-main-branch) and [auto generated implementation instructions](/workspace/branches#share-the-implementation-instructions), [Slack integration](/workspace/integrations#slack) to keep your team in the loop, [auto publishing](/workspace/tracking-plan/publishing) to keep your downstream schemas in sync, and more!
+The Avo Tracking Plan is a collaborative web app that will make managing your tracking plan less of a headache, with features like [Tracking Plan audit](/audit/overview) to ensure naming conventions are followed, [global event and property namespace](/data-design/global-namespace) to ensure consistency across your events and properties, [branched collaboration](/data-design/branches) with [approval workflows](/data-design/branches/approval-workflows) and [auto generated implementation instructions](/data-design/branches#share-the-implementation-instructions), [auto publishing](/publishing/publishing/overview) to keep your downstream schemas in sync, and more!
 
 When you have your tracking plan defined in Avo you can check out our [code generated, type-safe, functions](/implementation/avo-codegen-overview) for developers to increase tracking implementation speed and reliability, and tracking observability with the [Inspector](/data-design/start-using-inspector) so you know how your _actual_ tracking compares to the tracking plan.
 
@@ -24,7 +24,7 @@ If you have an existing tracking plan that you want to import, you can do so by 
 
 ![Import button in Avo workspace](/images/audit/import-button.png)
 
-You can import a tracking plan from any of the following sources: Excel or Google Sheets (.csv), Mixpanel Lexicon or Amplitude Govern. Learn more about the available import formats in the [importing docs](/workspace/tracking-plan/importing). If you have your tracking plan on a format that's currently not supported by the tracking plan importer, [reach out](/workspace/tracking-plan/importing) to us and we'll import it for you.
+You can import a tracking plan from any of the following sources: Excel or Google Sheets (.csv), Mixpanel Lexicon or Amplitude Govern. Learn more about the available import formats in the [importing docs](/publishing/importing). If you have your tracking plan on a format that's currently not supported by the tracking plan importer, [reach out](/publishing/importing) to us and we'll import it for you.
 
 <Callout type="info" emoji="💡">
   If you don't have an existing tracking plan, or if you just want to start
@@ -73,7 +73,7 @@ New and modified events are highlighted in the _workbench_ at the top of your tr
 
 ### Step 4: Invite a colleague and ask them for a review
 
-Now we're ready to share our suggestions with our team, and ask them for input. Go to your workspace settings and invite a team member. Workspace members can be one of admin, editor, comment only or view only. To learn more about members and roles, check out our [members docs](/workspace/members).
+Now we're ready to share our suggestions with our team, and ask them for input. Go to your workspace settings and invite a team member. Workspace members can be one of admin, editor, comment only or view only. To learn more about members and roles, check out our [members docs](/data-design/collaboration/members).
 
 ![Accessing workspace settings](/images/workspace/members/accessMembers.png)
 

--- a/pages/data-design/start-data-design.mdx
+++ b/pages/data-design/start-data-design.mdx
@@ -201,13 +201,13 @@ We always recommend adding a descriptive description to every event, that descri
 #### Add a source (required)
 
 Add a
-[source](/workspace/connections#a-namesourcesa-sources-where-the-data-comes-from) to your event to define where it should be sent from and in which programming language the tracking code will be generated in. If you have an established workspace you probably have the sources you need already set up and can select them from the drop down that appears when you click "+ Add Source". If not, you might need to set up and configure your sources and destinations in the
-[Sources tab](/workspace/connections).
+[source](/data-design/define-sources-and-destinations) to your event to define where it should be sent from and in which programming language the tracking code will be generated in. If you have an established workspace you probably have the sources you need already set up and can select them from the drop down that appears when you click "+ Add Source". If not, you might need to set up and configure your sources and destinations in the
+[Sources tab](/data-design/define-sources-and-destinations).
 
 #### Add actions and properties
 
 All events in Avo have the
-["Log Event" action](/workspace/tracking-plan/events#a-namelog-eventa-log-event) by default, which means that a user action is logged as an event to the analytics platform. This is the most common use case and the one that we are focusing on in this guide. With the "Log Event" action you can add event properties, which allows you to attach detailed information about the action the user performed. See how to create, add and configure event properties in the section below.
+["Log Event" action](/data-design/avo-tracking-plan/events#log-event) by default, which means that a user action is logged as an event to the analytics platform. This is the most common use case and the one that we are focusing on in this guide. With the "Log Event" action you can add event properties, which allows you to attach detailed information about the action the user performed. See how to create, add and configure event properties in the section below.
 
 #### Add a category
 
@@ -233,10 +233,10 @@ _Example: Configuring an event._
 ## Defining and configuring event properties
 
 In this guide we're focusing on
-[event properties](/workspace/tracking-plan/properties#a-nameevent-propertiesa-event-properties) on events with the Log Event action, as that is the most common use case for beginners. There are a few more
-[actions](/workspace/tracking-plan/events#a-nameactionsa-actions) available as well as two other kinds of properties (
-[user properties](/workspace/tracking-plan/properties#a-nameuser-propertiesa-user-properties) and
-[system properties](/workspace/tracking-plan/properties#a-namesystem-propertiesa-system-properties)).
+[event properties](/data-design/avo-tracking-plan/properties#event-properties) on events with the Log Event action, as that is the most common use case for beginners. There are a few more
+[actions](/data-design/avo-tracking-plan/events#actions) available as well as two other kinds of properties (
+[user properties](/data-design/avo-tracking-plan/properties#properties) and
+[system properties](/data-design/avo-tracking-plan/properties#system-properties)).
 
 ### Step 1 – Create a new event property
 

--- a/pages/faqs/faq-inspector.mdx
+++ b/pages/faqs/faq-inspector.mdx
@@ -42,7 +42,7 @@ Avo doesn’t need to know the actual values, we only need to understand the sha
 ### What does Avo do with my data?
 
 The [Avo Inspector SDK](/implementation/avo-inspector-sdk-reference)
-analyzes your user data and delivers metadata about the user data to Avo’s servers. Based on that metadata we build your tracking plan and [alert on any issues](/workspace/inspector#issue-types)
+analyzes your user data and delivers metadata about the user data to Avo’s servers. Based on that metadata we build your tracking plan and [alert on any issues](/inspector/inspector-overview#issue-types)
 .
 
 ### Does Avo batch events in the SDK?

--- a/pages/faqs/yes-you-can-faq.mdx
+++ b/pages/faqs/yes-you-can-faq.mdx
@@ -2,7 +2,7 @@
 
 ### Can I use Avo to diagnose analytics issues?
 
-Yes, you can! The [Avo Inspector SDK](/implementation/avo-inspector-sdk-reference) will automatically [monitor the health of your current tracking](/workspace/inspector) and suggest fixes for issues such as missing events or properties, casing inconsistencies, property type mismatches, significant difference in volumes between platforms and many more.
+Yes, you can! The [Avo Inspector SDK](/implementation/avo-inspector-sdk-reference) will automatically [monitor the health of your current tracking](/inspector/inspector-overview) and suggest fixes for issues such as missing events or properties, casing inconsistencies, property type mismatches, significant difference in volumes between platforms and many more.
 
 ### Can I use Avo without adjusting my Privacy Policy?
 
@@ -11,15 +11,14 @@ Yes, you can! Avo does not collect any user data. We only collect metadata about
 ### Can I use Avo to fix analytics issues?
 
 Yes, you can! The [Avo Inspector SDK](/implementation/avo-inspector-sdk-reference)
-will automatically [monitor the health of your current tracking](/workspace/inspector)
+will automatically [monitor the health of your current tracking](/inspector/inspector-overview)
 and suggest fixes for issues such as missing events or properties, casing inconsistencies, property type mismatches, significant difference in volumes between platforms and many more.
 
 ### Can I use Avo to generate analytics tracking code?
 
 Yes, you can! We offer a few different ways to do this. You can pull the [
 analytics wrappers from the CLI](/implementation/cli#step-3-pull-generated-analytics-wrappers-from-avo)
-, or you can copy them from [within the Avo UI](/workspace/implement#a-nameavo-filea-get-the-avo-file)
-.
+, or you can copy them from the Codegen tab within the Avo UI.
 
 ### Can I use Inspector on my dev environment? What about production?
 
@@ -37,7 +36,7 @@ and tags to keep track of events from different product features.
 ### Can I implement platform-specific events or metrics?
 
 Yes, you can! Within the Avo UI, you will be able to select platform-specific sources and destinations if you are on the Team or Enterprise Plans. For more information about source availability, [
-check out what we support here](/workspace/connections#a-namesourcesa-sources-where-the-data-comes-from)
+check out what we support here](/data-design/define-sources-and-destinations#sources-where-the-data-comes-from)
 .
 
 ### Can I use Avo with my git workflow?
@@ -107,39 +106,39 @@ Yes, you can! [Check out our integration here](/data-design/analytics#intercom)
 ### Can I publish my Avo tracking plan to Segment Protocols?
 
 Yes, you can! We integrate directly with Segment Protocols. [
-Find out more here](/workspace/tracking-plan/publishing#a-namesegment-protocolsa-segment-protocols)
+Find out more here](/publishing/publishing/overview#segment-protocols)
 .
 
 ### Can I publish my Avo tracking plan to RudderStack?
 
-Yes, you can! We integrate directly with RudderStack. [Find out more here](/workspace/tracking-plan/publishing#rudderstack)
+Yes, you can! We integrate directly with RudderStack. [Find out more here](/publishing/publishing/overview#rudderstack)
 .
 
 ### Can I publish my Avo tracking plan to mParticle Data Master?
 
-Yes, you can! We integrate directly with mParticle Data Master. [Find out more here](/workspace/tracking-plan/publishing#mparticle)
+Yes, you can! We integrate directly with mParticle Data Master. [Find out more here](/publishing/publishing/overview#mparticle)
 .
 
 ### Can I publish my Avo tracking plan to Mixpanel Lexicon?
 
 Yes, you can! We integrate with Mixpanel Lexicon. [
-Find out more here](/workspace/tracking-plan/publishing#a-namemixpanel-lexicona-mixpanel-lexicon)
+Find out more here](/publishing/publishing/overview#mixpanel-lexicon)
 .
 
 ### Can I publish my Avo tracking plan to Snowplow?
 
-Yes, you can! We integrate directly with Snowplow. [Find out more here](/workspace/tracking-plan/publishing#snowplow)
+Yes, you can! We integrate directly with Snowplow. [Find out more here](/publishing/publishing/overview#snowplow)
 .
 
 ### Can I publish my Avo tracking plan to Amplitude Govern?
 
 Yes, you can! We integrate with Amplitude’s Govern (Taxonomy) tool. [
-Check out our integration here](/workspace/tracking-plan/publishing#a-nameamplitude-governa-amplitude-govern)
+Check out our integration here](/publishing/publishing/overview#amplitude-govern)
 .
 
 ### Can I publish my Avo tracking plan to my custom tracking tool?
 
-Yes, you can! [Check out our Webhook integration here](/workspace/tracking-plan/publishing#a-namewebhooka-webhook)
+Yes, you can! [Check out our Webhook integration here](/publishing/publishing/overview#webhook)
 .
 
 ### Can I implement Avo with JavaScript?
@@ -209,12 +208,12 @@ Yes, you can! For more information on the languages we support, [check out our d
 
 ### Can I export my tracking plan from Avo?
 
-Yes, you can! You can use our [publishing feature](/workspace/tracking-plan/publishing)
+Yes, you can! You can use our [publishing feature](/publishing/publishing/overview)
 to export it on either JSON schema format with a Webhook or the Amplitude/Mixpanel/Segment formats.
 
 ### Can I document my metrics in context with my tracking plan?
 
-Yes, you can! We recommend [defining metrics](/workspace/tracking-plan/metrics)
+Yes, you can! We recommend [defining metrics](/data-design/avo-tracking-plan/metrics)
 before adding events to your tracking plan. In Avo, they are connected to events and help stakeholders understand why this event is being tracked.
 
 ### Can I use Avo to QA my events?
@@ -228,7 +227,7 @@ Yes you can! Avo’s property library is global in scope, so you don’t have to
 
 ### Can I define what property values are allowed in Avo?
 
-Yes you can! [Property constraints](/data-design/defining-descriptive-events-and-properties#a-nameproperty-constraintsa-property-constraints)
+Yes you can! [Property constraints](/data-design/defining-descriptive-events-and-properties#property-constraints)
 within Avo allow you to create predefined rules about the values you will allow for any given property. Say goodbye to the days of nonsense metadata like “age” = “-1”.
 
 ### Can I use Avo in my unit tests?
@@ -238,13 +237,13 @@ can be initialized with a noop flag that disables network requests and only run 
 
 ### Can I add descriptions to my events and properties with Avo?
 
-Yes you can! [Defining descriptive events and properties](/data-design/defining-descriptive-events-and-properties#a-namedescriptionsa-descriptions-for-events-and-properties)
+Yes you can! [Defining descriptive events and properties](/data-design/defining-descriptive-events-and-properties#descriptions-for-events-and-properties)
 is a best practice for keeping all your current and future teammates on the same page.
 
 ### Can I use Avo to help stick to my naming convention?
 
-Yes, you can! In Inspector, you will see issues when naming conventions have been violated. You will also receive [feedback in event and property naming modals](/data-design/defining-descriptive-events-and-properties#a-namenaming-conventionsa-naming-conventions-for-events-and-properties)
-and a summary in our [issue reporter](/workspace/tracking-plan/issue-reporter)
+Yes, you can! In Inspector, you will see issues when naming conventions have been violated. You will also receive [feedback in event and property naming modals](/data-design/defining-descriptive-events-and-properties#naming-conventions-for-events-and-properties)
+and a summary in our [issue reporter](/audit/overview)
 within your tracking plan.
 
 [Get in touch](/help/troubleshooting) for more information.

--- a/pages/implementation/avo-codegen-overview.mdx
+++ b/pages/implementation/avo-codegen-overview.mdx
@@ -6,7 +6,7 @@ import { Callout } from 'nextra/components';
 
 Codegen produces type safe code for implementing analytics.
 
-- The "data designer" specifies the event structure in the [Avo Tracking Plan](/workspace), and which platforms should send the event
+- The "data designer" specifies the event structure in the [Avo Tracking Plan](/data-design/avo-tracking-plan), and which platforms should send the event
 - then the developer who implements analytics can use Codegen to implement the analytics calls per each analytics event
 
 ## Why use Codegen
@@ -34,7 +34,7 @@ Codegen works with any analytics tool, whether it's any of the common event logg
 
 When designing the tracking plan you configure the list of data destinations for each source. In the generated code each destination is represented as its own Destination Interface in the initAvo method. This is how Codegen routes data, locally in your client (without the data ever going through Avo's servers), to the correct destination based on the source/destination connections you've defined in the Avo dashboard.
 
-In the Avo Tracking Plan you can configure which analytics [actions](/workspace/tracking-plan/events#a-nameactionsa-actions) should be included in Codegen (for example you might want to update user properties or log revenue along with logging an event), and Codegen will handle calling all the relevant Destination Interface methods. All you have to do is call the generated function in your code base and pass in type safe key-value pairs, and the Codegen will take care of the rest.
+In the Avo Tracking Plan you can configure which analytics [actions](/data-design/avo-tracking-plan/events#actions) should be included in Codegen (for example you might want to update user properties or log revenue along with logging an event), and Codegen will handle calling all the relevant Destination Interface methods. All you have to do is call the generated function in your code base and pass in type safe key-value pairs, and the Codegen will take care of the rest.
 
 Learn more in the [Codegen tech deep dive docs](/implementation/avo-codegen-tech-deep-dive).
 

--- a/pages/implementation/avo-codegen-tech-deep-dive.mdx
+++ b/pages/implementation/avo-codegen-tech-deep-dive.mdx
@@ -7,7 +7,7 @@ import { Callout } from 'nextra/components';
 The Avo generated code is the representation of the tracking plan you define in Avo for a given source. You can think of a source as a platform that sends events.
 For example if you set up an iOS/Swift source the generated code will be in a `.swift` file.
 Since the tracking plans are different for each customer the content of this file is also different.
-We generate the files and you can download them either with [the Avo CLI](/implementation/cli) or in the Avo web interface in [Codegen tab](/workspace/implement).
+We generate the files and you can download them either with [the Avo CLI](/implementation/cli) or in the Avo web interface in [Codegen tab](/implementation/guides/download-or-copy-avo-file-manually).
 
 First of all, feel free to explore your generated file. It's deliberately designed to be easily readable. Our code generation is under active development and some advanced or new features may slightly differ from one platform to another.
 The generated file is the best source of truth when looking for implementation details.
@@ -22,7 +22,7 @@ The generated file is the best source of truth when looking for implementation d
   Make sure all the events you want to implement using Codegen have the source
   attached to it, where "Implement with Codegen" has been checked. Learn more
   about how to [configure events in your tracking plan
-  here](/workspace/tracking-plan/events#sources).
+  here](/data-design/avo-tracking-plan/events#sources).
 </Callout>
 
 ### Avo Command Line Interface
@@ -57,7 +57,7 @@ Learn more about the CLI [here](/implementation/cli).
 
 First thing you need to do after importing the generated file is to initialize Avo.
 There will either be a static `initAvo` method or a class, named `Avo` by default, with a constructor, depending on your setup. [Contact us](/help/troubleshooting) if you want to change the setup.
-Regardless of the option, the arguments you would need to provide are the same, and based on your tracking plan. Check out the [Codegen tab](/workspace/implement) for specific recommendations.
+Regardless of the option, the arguments you would need to provide are the same, and based on your tracking plan. Check out the [Codegen tab](/implementation/guides/download-or-copy-avo-file-manually) for specific recommendations.
 Samples below are in Swift and the code is very similar in other programming languages:
 
 ```swift
@@ -147,7 +147,7 @@ Each event in your tracking plan added to Codegen creates an event function that
 <Callout type="info" emoji="📖">
 **Read more about actions and supported tracking methods:**
 
-Read about [available Actions and how they work in the tracking plan](/workspace/tracking-plan/events#actions).
+Read about [available Actions and how they work in the tracking plan](/data-design/avo-tracking-plan/events#actions).
 
 Learn how [you can implement supported tracking methods in your destinations](/implementation/destinations).
 
@@ -203,7 +203,7 @@ object properties: exact structure of the allowed keys and types of values in th
 
 Avo makes sure that the event names and provided properties are correct according to the tracking plan with compile time and runtime validations and development invocations are reported to Avo servers so you can check the invocation status on the Avo website.
 
-Then it sends the provided data to all the configured analytics destinations, using the destination interfaces you've defined during initialization. There are different [actions](/workspace/tracking-plan/events#a-nameactionsa-actions) that can be tracked:
+Then it sends the provided data to all the configured analytics destinations, using the destination interfaces you've defined during initialization. There are different [actions](/data-design/avo-tracking-plan/events#actions) that can be tracked:
 identify, log event, update user properties, unidentify, log revenue, log page view, but everything is checked and the payload is prepared inside the Avo file and delivered in a correct form to the destination interfaces.
 
 The Avo generated tracking code will look similar to this:
@@ -221,7 +221,7 @@ secondDestination.logEvent(eventName: "Logged Out", eventProperties: customDestE
 secondDestination.unidentify()
 ```
 
-This particular event has `log event` and `unidentify` actions. The methods called above will vary based on the actions of the given event. [Read more about actions here](/workspace/tracking-plan/events#a-nameactionsa-actions).
+This particular event has `log event` and `unidentify` actions. The methods called above will vary based on the actions of the given event. [Read more about actions here](/data-design/avo-tracking-plan/events#actions).
 
 ### Data Validations
 

--- a/pages/implementation/avo-tracking-plan-webhook.mdx
+++ b/pages/implementation/avo-tracking-plan-webhook.mdx
@@ -1,12 +1,12 @@
 # Subscribe to Tracking Plan changes with webhooks
 
-After setting up Webhook integration in [Tracking Plan Publishing](/workspace/tracking-plan/publishing), your endpoint provided there will be called with a JSON payload representing the state of your tracking plan when your tracking plan is published.
+After setting up Webhook integration in [Tracking Plan Publishing](/publishing/publishing/overview), your endpoint provided there will be called with a JSON payload representing the state of your tracking plan when your tracking plan is published.
 
 You can examine and download the exact JSON in the Publishing tab of your [Avo workspace](https://www.avo.app/schemas/).
 
 > To see your exact Webhook payload in your Avo workspace choose `Tracking plan` - `Publishing` in the sidebar, then pick you Webhook in the menu and expand the `Payload preview` section.
 
-[The format is documented here](/workspace/tracking-plan/publishing#tracking-plan-model), an example payload is:
+[The format is documented here](/publishing/publishing/overview#tracking-plan-model), an example payload is:
 
 ```JSON
 {

--- a/pages/implementation/devs-101.mdx
+++ b/pages/implementation/devs-101.mdx
@@ -12,9 +12,9 @@ Avo offers three ways to validate your tracking implementation:
 
 ### What is Codegen?
 
-[Codegen](/implementation/avo-codegen-overview) produces type safe analytics wrappers that are code generated based on your [tracking plan](/workspace).
+[Codegen](/implementation/avo-codegen-overview) produces type safe analytics wrappers that are code generated based on your [tracking plan](/data-design/avo-tracking-plan).
 
-Technical or non-technical people can define analytics event schemas in the [Avo Tracking Plan](/workspace),
+Technical or non-technical people can define analytics event schemas in the [Avo Tracking Plan](/data-design/avo-tracking-plan),
 and you can generate human readable type safe code based on that. The days of unstructured
 and outdated tracking plan spreadsheets and Jira tickets are over 🥳 So are the days of brittle
 analytics implementation you have to revisit to fix again and again and again 😌
@@ -30,7 +30,7 @@ represented as its own Destination Interface in the initAvo method of your Codeg
 locally in your client (without the data ever going through Avo's servers), to the correct destination based on the source/destination connections
 you've defined in the Avo dashboard.
 
-In the [Avo Tracking Plan](/workspace) you can configure which analytics [actions](/workspace/tracking-plan/events#a-nameactionsa-actions)
+In the [Avo Tracking Plan](/data-design/avo-tracking-plan) you can configure which analytics [actions](/data-design/avo-tracking-plan/events#actions)
 should be triggered with an Avo Function (for example you might want to update user properties or log revenue along with logging an event), and Codegen
 will handle calling all the relevant Destination Interface methods. All you have to do is call the Avo Function in your
 code base and pass in type safe key-value pairs, and the Avo Function will take care of the rest.
@@ -66,7 +66,7 @@ the Avo servers. To repeat: None of the PII data ever flows through Avo servers;
 
 ### How do I use Inspector?
 
-You can view the overview of your current tracking in the [Inspector dashboard](/workspace/inspector) and you can connect Avo Inspector to a Slack channel to receive alerts when Inspector detects
+You can view the overview of your current tracking in the [Inspector dashboard](/inspector/inspector-overview) and you can connect Avo Inspector to a Slack channel to receive alerts when Inspector detects
 a new issue that has not been seen in production for 30 days.
 
 ### How do I send data into Inspector?
@@ -98,9 +98,9 @@ Initialize Codegen SDK with an instance of Inspector SDK.
 
 You can pipe your analytics data into Inspector API via your CDPs or analytics providers:
 
-- Segment: [Set Inspector up via Segment Functions](/workspace/connect-inspector-to-segment)
-- RudderStack: [Set Inspector up via RudderStack Functions](/workspace/connect-inspector-to-rudderstack)
-- PostHog: [Set Inspector up via PostHog Plugin](/workspace/connect-inspector-to-posthog)
+- Segment: [Set Inspector up via Segment Functions](/inspector/connect-inspector-to-segment)
+- RudderStack: [Set Inspector up via RudderStack Functions](/inspector/connect-inspector-to-rudderstack)
+- PostHog: [Set Inspector up via PostHog Plugin](/inspector/connect-inspector-to-posthog)
 - Mixpanel: Coming soon.
 - mParticle: Coming soon.
 

--- a/pages/implementation/guides/avo-and-git.mdx
+++ b/pages/implementation/guides/avo-and-git.mdx
@@ -16,7 +16,7 @@ Let’s say the iOS team at our fictional company is working on an updated check
 
 #### Branched tracking plan changes
 
-First, they [open a new branch](/workspace/branches#how-to-create-branches) in their Avo tracking plan, where they can modify the tracking plan without changing it for anyone else. They [create the new events](/data-design/day-to-day-workflow#a-namestep-3-defining-events-and-propertiesa-step-3--define-events-and-properties), and mark them to be [sent from the iOS source](/workspace/tracking-plan/events#sources). They add the new properties to the existing events and [mark the properties to be always sent on iOS](/workspace/tracking-plan/properties#a-nameproperty-presence-configurationa-configuring-when-properties-are-required-or-optional).
+First, they [open a new branch](/data-design/branches#how-to-create-branches) in their Avo tracking plan, where they can modify the tracking plan without changing it for anyone else. They [create the new events](/data-design/day-to-day-workflow#step-3--define-events-and-properties), and mark them to be [sent from the iOS source](/data-design/avo-tracking-plan/events#sources). They add the new properties to the existing events and [mark the properties to be always sent on iOS](/data-design/avo-tracking-plan/properties#configuring-when-properties-are-required-or-optional).
 
 ![Onboarding flow event in Avo, sent from iOS](/images/best-practices/avo-in-large-dev-teams/event-sent-from-ios.png)
 
@@ -28,7 +28,7 @@ _Property always sent from iOS, never from Android_
 
 #### Branched tracking plan implementation
 
-When the tracking plan changes made on the branch have been [peer-reviewed and approved](/data-design/day-to-day-workflow#a-namestep-4-ask-for-reviewa-step-4--ask-for-review) in Avo, they can start the tracking implementation.
+When the tracking plan changes made on the branch have been [peer-reviewed and approved](/data-design/day-to-day-workflow#step-4--ask-for-review) in Avo, they can start the tracking implementation.
 
 Using [the Avo CLI](/implementation/cli#using-avo-branches) the iOS developer can pull their type-safe generated Avo code based on the tracking plan from the Avo branch, into their feature branch on git: `avo pull new-onboarding-events` where `new-onboarding-events` is the Avo branch containing the Tracking Plan changes. By doing so, they've pinned the `avo.json` file in their project to the current state of the Tracking Plan on that Avo branch.
 

--- a/pages/implementation/guides/property-bundles-unbundling.mdx
+++ b/pages/implementation/guides/property-bundles-unbundling.mdx
@@ -12,7 +12,7 @@ We add this property bundle to any event that is related to a source instead of 
 
 Property bundles can include more than 2 properties, there is no upper limit.
 
-Read more about property bundles [here](/workspace/tracking-plan/properties#a-nameproperty-bundlesa-event-property-bundles).
+Read more about property bundles [here](/data-design/avo-tracking-plan/properties#event-property-bundles).
 
 ## Property bundles in Avo Codegen
 

--- a/pages/implementation/guides/start-implementing-tracking-changes.mdx
+++ b/pages/implementation/guides/start-implementing-tracking-changes.mdx
@@ -17,7 +17,7 @@ We suggest using comments in the code changes view to ask for any clarification 
 
 ![Overview of code changes](/images/code-changes/code-changes.png)
 
-Read more on [the branch changes view](/workspace/code-changes).
+Read more on [the branch changes view](/data-design/branches/code-changes).
 
 ## Pull the new code with Avo CLI
 

--- a/pages/implementation/guides/start-using-inspector-with-avo-codegen.mdx
+++ b/pages/implementation/guides/start-using-inspector-with-avo-codegen.mdx
@@ -4,7 +4,7 @@ You need to do minor setup to enable **Codegen** to start reporting to **Avo Ins
 
 Common steps for all platforms:
 
-1. Avo Inspector should be enabled for given source. Open [Inspector tab](/workspace/inspector) in the side menu in your [Avo workspace](https://www.avo.app/schemas/), then press "Manage Sources" button at the top, choose your source from the grid and wait until you see the `API Key`. Once the `API Key` appears you source is considered Inspector-enabled.
+1. Avo Inspector should be enabled for given source. Open [Inspector tab](/inspector/inspector-overview) in the side menu in your [Avo workspace](https://www.avo.app/schemas/), then press "Manage Sources" button at the top, choose your source from the grid and wait until you see the `API Key`. Once the `API Key` appears you source is considered Inspector-enabled.
 
 2. Your Avo generated file should use Avo version 63.10.0 or greater. You can find the version in the comment at the top of the generated file. If the version is older than 63.10.0 run `avo pull` again.
 

--- a/pages/implementation/start-using-avo-codegen.mdx
+++ b/pages/implementation/start-using-avo-codegen.mdx
@@ -68,7 +68,7 @@ _Our Source and Destination_
 
 #### Configure events
 
-Head to the Tracking Plan tab. If no events exist in your tracking plan yet you can either [import your existing tracking plan](/workspace/tracking-plan/importing) or [define events in the Tracking Plan](/data-design/start-data-design#defining-and-configuring-events). Make sure to attach the source you'll be implementing to all events you want to implement. Learn more about [attaching sources to events here](/workspace/tracking-plan/events#sources).
+Head to the Tracking Plan tab. If no events exist in your tracking plan yet you can either [import your existing tracking plan](/publishing/importing) or [define events in the Tracking Plan](/data-design/start-data-design#defining-and-configuring-events). Make sure to attach the source you'll be implementing to all events you want to implement. Learn more about [attaching sources to events here](/data-design/avo-tracking-plan/events#sources).
 
 ### 2. Install Avo to your project
 
@@ -211,7 +211,7 @@ Detailed instructions on how to initialize Avo with Custom Destinations for all 
 
 #### Send an event
 
-Now we're ready to start implementing reliably analytics tracking with Codegen. Every Event defined in our [Tracking Plan on avo.app](/workspace/tracking-plan) has it's own function in Codegen file.
+Now we're ready to start implementing reliably analytics tracking with Codegen. Every Event defined in our [Tracking Plan on avo.app](/data-design/avo-tracking-plan) has it's own function in Codegen file.
 
 Let's say we have defined the "App Opened" event in our Tracking Plan in Avo, with two Event Properties, "Client" and "Screen Name". Here's how we would send the event using Codegen:
 
@@ -222,5 +222,3 @@ Avo.appOpened({ client: 'Web', screenName: 'Home Screen' });
 > On some server platforms Codegen functions are async, e.g. on Node.js they return a Promise and on C# you can await on the functions
 
 When the Avo Function is called Avo will run validation on the event properties, making sure they fit the spec defined in the Tracking Plan in Avo. Note that this validation is only run in development mode. If you are using a Custom destination Avo passes the event name and properties to the logEvent function in the Custom Destination interface defined above, otherwise it will pass the event directly to the analytics tool defined in your destination.
-
-You can find tailor made documentation for your Codegen, based on your Tracking Plan, in the [Codegen tab](/workspace/implement#a-nameimplement-actionsa-implement-events) in [your Avo workspace](https://www.avo.app/welcome).

--- a/pages/inspector/add-events-from-inspector.mdx
+++ b/pages/inspector/add-events-from-inspector.mdx
@@ -1,6 +1,6 @@
 # Add Events and properties from Inspector
 
-The Inspector compares the ingested events and properties against tracking plan and detects if there are any events or properties missing from the tracking plan. Unknown events and properties can both be added to the tracking plan from both the [Issues view](/workspace/inspector/inspector-issues-view) and the [Events view](/workspace/inspector/inspector-events-view).
+The Inspector compares the ingested events and properties against tracking plan and detects if there are any events or properties missing from the tracking plan. Unknown events and properties can both be added to the tracking plan from both the [Issues view](/inspector/inspector-issues-view) and the [Events view](/inspector/inspector-events-view).
 
 ## Event not in Tracking Plan
 

--- a/pages/inspector/configuring-inspector-sources.mdx
+++ b/pages/inspector/configuring-inspector-sources.mdx
@@ -2,7 +2,7 @@
 
 _How to connect Inspector to your data stream._
 
-The first step to start using Inspector, is installing it on your sources. Inspector shares sources with the workspace sources and they are all set up in the Sources tab. You can find the source setup in Inspector [Issues view](/workspace/inspector/inspector-issues-view) and the [Events view](/workspace/inspector/inspector-events-view) by clicking "+ Add Source" or navigate to the "Sources" tab directly.
+The first step to start using Inspector, is installing it on your sources. Inspector shares sources with the workspace sources and they are all set up in the Sources tab. You can find the source setup in Inspector [Issues view](/inspector/inspector-issues-view) and the [Events view](/inspector/inspector-events-view) by clicking "+ Add Source" or navigate to the "Sources" tab directly.
 
 ![Opening a branch](/images/workspace/nav-inspector-sources-highlighted.png)
 

--- a/pages/inspector/connect-inspector-to-posthog.mdx
+++ b/pages/inspector/connect-inspector-to-posthog.mdx
@@ -24,7 +24,7 @@ Open `Sources` in the Avo sidebar or `Manage Sources` in Inspector tab
 
 ![Navigation to Inspector sources screen in Avo](/images/workspace/nav-inspector-sources-highlighted.png)
 
-If you already have the source, open it in the dashboard. If you don’t have the source corresponding to your app, [add a new one](/workspace/inspector#configuring-sources).
+If you already have the source, open it in the dashboard. If you don’t have the source corresponding to your app, [add a new one](/inspector/inspector-overview#configuring-sources).
 
 ![Image of the Add Source button in Avo](/images/add-source.png)
 

--- a/pages/inspector/connect-inspector-to-rudderstack.mdx
+++ b/pages/inspector/connect-inspector-to-rudderstack.mdx
@@ -30,7 +30,7 @@ Open `Sources` in the Avo sidebar or `Manage Sources` in Inspector tab
 ![Navigation to Inspector sources screen in Avo](/images/workspace/nav-inspector-sources-highlighted.png)
 src={'/docs'}
 
-If you already have the source, pick it. If you don’t have the source corresponding to your app, [add a new one](/workspace/inspector#configuring-sources).
+If you already have the source, pick it. If you don’t have the source corresponding to your app, [add a new one](/inspector/inspector-overview#configuring-sources).
 
 ![Image of the Add Source button in Avo](/images/add-source.png)
 src={'/docs'}

--- a/pages/inspector/connect-inspector-to-segment.mdx
+++ b/pages/inspector/connect-inspector-to-segment.mdx
@@ -36,7 +36,7 @@ Open `Sources` in the Avo sidebar or `Manage Sources` in Inspector tab
 
 ![Navigation to Inspector sources screen in Avo](/images/workspace/nav-inspector-sources-highlighted.png)
 
-If you already have the source, pick it. If you don’t have the source corresponding to your app, [add a new one](/workspace/inspector#configuring-sources).
+If you already have the source, pick it. If you don’t have the source corresponding to your app, [add a new one](/inspector/inspector-overview#configuring-sources).
 
 ![Image of the Add Source button in Avo](/images/add-source.png)
 

--- a/pages/inspector/inspector-events-view.mdx
+++ b/pages/inspector/inspector-events-view.mdx
@@ -64,8 +64,8 @@ You can learn more about the [issue types Inspector can detect in your tracking 
 
 ## Inspector Implementation Status
 
-You can learn more about [how Inspector works with your Tracking Plan implementation status here](/workspace/tracking-plan/implementation-status).
+You can learn more about [how Inspector works with your Tracking Plan implementation status here](/data-design/avo-tracking-plan/implementation-status).
 
 ## Adding events to your tracking plan directly from the Inspector
 
-You can learn more about [how you can create events and properties directly from the inspector here](/workspace/add-events-from-inspector)
+You can learn more about [how you can create events and properties directly from the inspector here](/inspector/add-events-from-inspector)

--- a/pages/inspector/inspector-overview.mdx
+++ b/pages/inspector/inspector-overview.mdx
@@ -8,9 +8,9 @@ We built Inspector to help you understand how your current tracking is performin
 
 In this section of the Inspector docs we'll be covering how to configure and use Inspector in your workspace. You can learn about [how to install Inspector SDKs in your sources here](/implementation/avo-inspector-sdk-reference).
 
-- [Configuring Inspector Sources](/workspace/inspector/configuring-inspector-sources): how to set up sources to connect Inspector to your data stream
-- [Events view](/workspace/inspector/inspector-events-view): How the Inspector Events view works and how to use it
-- [Issues view (beta)](/workspace/inspector/inspector-issues-view): How the Inspector Issues view works and how to use it
+- [Configuring Inspector Sources](/inspector/configuring-inspector-sources): how to set up sources to connect Inspector to your data stream
+- [Events view](/inspector/inspector-events-view): How the Inspector Events view works and how to use it
+- [Issues view (beta)](/inspector/inspector-issues-view): How the Inspector Issues view works and how to use it
 - [Issue types](/explore-tracking-plan/issue-types-in-inspector): Which issues does Inspector detect and what they mean
-- [Slack alerts](/workspace/inspector/inspector-slack-alerts): How to configure Inspector to send alerts via Slack
-- [Add events from Inspector](/workspace/add-events-from-inspector): How to add events and properties to your tracking plan from Inspector
+- [Slack alerts](/inspector/inspector-slack-alerts): How to configure Inspector to send alerts via Slack
+- [Add events from Inspector](/inspector/add-events-from-inspector): How to add events and properties to your tracking plan from Inspector

--- a/pages/inspector/start-using-inspector.mdx
+++ b/pages/inspector/start-using-inspector.mdx
@@ -31,8 +31,8 @@ TL;DR: No PII data ever flows through Avo servers; only event schemas.
 
 ## Learning about Inspector issues
 
-After [setting up your sources](/workspace/inspector#configuring-sources) to send data to the Inspector with the direct CDP integrations or [Avo Inspector SDKs](/implementation/avo-inspector-sdk-reference) you will see the data appearing in the the Inspector tab.
-There are two Inspector overviews available for your incoming data and issues, the [Issues view](/workspace/inspector/inspector-issues-view) and the [Events view](/workspace/inspector/inspector-events-view) – and you can set up [Slack Alerts](/workspace/inspector/inspector-slack-alerts) to be notified about new issues.
+After [setting up your sources](/inspector/inspector-overview#configuring-sources) to send data to the Inspector with the direct CDP integrations or [Avo Inspector SDKs](/implementation/avo-inspector-sdk-reference) you will see the data appearing in the the Inspector tab.
+There are two Inspector overviews available for your incoming data and issues, the [Issues view](/inspector/inspector-issues-view) and the [Events view](/inspector/inspector-events-view) – and you can set up [Slack Alerts](/inspector/inspector-slack-alerts) to be notified about new issues.
 
 ### Issues view
 
@@ -40,7 +40,7 @@ The Inspector issues view displays information about anomalies and discrepancies
 
 ![Image shows an example default view of the Inspector issues view.](/images/inspector/inspector-issues-default.png)
 
-Learn more about the [Issues view here](/workspace/inspector/inspector-issues-view).
+Learn more about the [Issues view here](/inspector/inspector-issues-view).
 
 ### Events view
 
@@ -48,7 +48,7 @@ The Inspector events view provides a report on all event tracking Inspector has 
 
 ![Inspector tab](/images/workspace/nav-inspector.png)
 
-Learn more about the [Events view here](/workspace/inspector/inspector-events-view).
+Learn more about the [Events view here](/inspector/inspector-events-view).
 
 > The production environment in Inspector is designed to handle large amounts of data and has up to 2 hours delay from receiving events to displaying them on a dashboard.
 
@@ -64,9 +64,9 @@ The main benefit of this solution is that it does not require work from a develo
 
 Learn how to route event to Inspector from:
 
-- [Segment](/workspace/connect-inspector-to-segment)
-- [RudderStack](/workspace/connect-inspector-to-rudderstack)
-- [PostHog](/workspace/connect-inspector-to-posthog)
+- [Segment](/inspector/connect-inspector-to-segment)
+- [RudderStack](/inspector/connect-inspector-to-rudderstack)
+- [PostHog](/inspector/connect-inspector-to-posthog)
 - Contact us if you want to use another [CDP](/help/troubleshooting)
 
 ### Install Inspector with an HTML tag

--- a/pages/publishing/exporting.mdx
+++ b/pages/publishing/exporting.mdx
@@ -16,14 +16,14 @@ To export your tracking plan Schema:
 
 ## Automated Webhook export
 
-[Publishing integrations](/workspace/tracking-plan/publishing) can be used for exporting your tracking plan, either one of, or a recurring
+[Publishing integrations](/publishing/publishing/overview) can be used for exporting your tracking plan, either one of, or a recurring
 publishing export using auto-publishing.
 
 To export your tracking plan on a JSON Schema format:
 
 1. Head to Tracking Plan > **Publish** in the sidebar of your Avo workspace
 2. Create a Webhook integration
-3. In the "Payload preview" section click "Click to view payload preview". When the preview has loaded you can either copy or download the JSON file. You can find more details on the format of the JSON in the [Publishing docs](/workspace/tracking-plan/publishing#tracking-plan-model).
+3. In the "Payload preview" section click "Click to view payload preview". When the preview has loaded you can either copy or download the JSON file. You can find more details on the format of the JSON in the [Publishing docs](/publishing/publishing/overview#tracking-plan-model).
 
 ![](/images/workspace/webhook-export.png)
 
@@ -41,4 +41,4 @@ You can 'avo pull' a JSON Schema representation of your tracking plan via the Av
 
 ## What's next?
 
-If you find yourself regularly exporting, you might want to [configure Auto-Publishing](/workspace/tracking-plan/publishing) for your tracking plan to consistently stay up to date with a downstream tool such as your analytics platform, your production time validation solution, your SQL table management, etc.
+If you find yourself regularly exporting, you might want to [configure Auto-Publishing](/publishing/publishing/overview) for your tracking plan to consistently stay up to date with a downstream tool such as your analytics platform, your production time validation solution, your SQL table management, etc.

--- a/pages/publishing/importing.mdx
+++ b/pages/publishing/importing.mdx
@@ -29,7 +29,7 @@ quickly.
   group properties, and name mapping.
 </Callout>
 
-See [supported formats for importing event schemas, aka tracking plans](/workspace/tracking-plan/importing#tracking-plan-import-formats).
+See [supported formats for importing event schemas, aka tracking plans](/publishing/importing#tracking-plan-import-formats).
 
 ![Screenshot of the Avo Importer](/images/workspace/importing/avo-importer.png)
 
@@ -39,20 +39,20 @@ See [supported formats for importing event schemas, aka tracking plans](/workspa
   **User properties** are helpful to segment behaviors by current state of
   users, as opposed to the state at the time of an event trigger. Read about
   [user property use cases and how they
-  work](/workspace/tracking-plan/properties#user-properties).
+  work](/data-design/avo-tracking-plan/properties#user-properties).
 </Callout>
 
-See [supported formats for importing user properties](/workspace/tracking-plan/importing#user-property-import-format).
+See [supported formats for importing user properties](/publishing/importing#user-property-import-format).
 
 ### Import Group Properties
 
 <Callout>
   **Group analytics** are important for b2b companies and can be useful in many
   other cases. Read about [group analytics use cases and how it
-  works](/workspace/data-design/groups).
+  works](/data-design/best-practices/groups).
 </Callout>
 
-See [supported formats for importing group properties](/workspace/tracking-plan/importing#group-property-import-format).
+See [supported formats for importing group properties](/publishing/importing#group-property-import-format).
 
 ### Import Name Mapping
 
@@ -104,7 +104,7 @@ name mappings for event and property names.
 
 ### Importing from a Google Sheet
 
-Avo supports importing various tracking plan formats. See [supported formats for importing tracking plans](/workspace/tracking-plan/importing#tracking-plan-import-formats).
+Avo supports importing various tracking plan formats. See [supported formats for importing tracking plans](/publishing/importing#tracking-plan-import-formats).
 
 #### How to import from a Google Sheet
 
@@ -215,7 +215,7 @@ CSV format for importing.
   other event related columns empty. 3. If you want to import user properties
   without associating them with an event, leave the event related columns empty
   Read [how user properties
-  work](/workspace/tracking-plan/properties#user-properties).
+  work](/data-design/avo-tracking-plan/properties#user-properties).
 </Callout>
 
 **Note:**
@@ -254,7 +254,7 @@ CSV format for importing.
 | Group Type                   | The group type (e.g. "Workspace" if you have a Workspace group)               | Workspace                                                                                     |
 | Property Name                | The name of the property as you want it sent to the analytics destination     | Member Count                                                                                  |
 | Property Description         | The description of the property                                               | The number of members of a workspace                                                          |
-| Property Value Type          | The type of the property                                                      | int (see [supported types](/workspace/tracking-plan/roperties#property-types-and-constraints) |
+| Property Value Type          | The type of the property                                                      | int (see [supported types](/data-design/avo-tracking-plan/properties#property-types-and-constraints) |
 | )                            |
 | Is Property Array?           | "Y" or "N" for whether this property is an array of property values           | "Y"                                                                                           |
 | Sent with Events             | "/" separated list of events with which this group property should be updated | Invite Accepted / Member Removed                                                              |
@@ -278,9 +278,9 @@ of what the property should contain in different context.
 
 In the case where you have aligned your names and types, but the description is different, you can:
 
-- **If the properties should be merged and you are in a position to reset your tracking plan**: Unify the description in your import file, [reset the tracking plan](/workspace/eset-tracking-plan)
+- **If the properties should be merged and you are in a position to reset your tracking plan**: Unify the description in your import file, [reset the tracking plan](/data-design/guides/reset-tracking-plan)
   , and re-run the import. This will result in the properties being merged on import.
-- **If the properties should be merged**: Use the ["Replace property with..." feature](/workspace/tracking-plan/properties#replacing-a-property) in the context menu of the property modal
+- **If the properties should be merged**: Use the ["Replace property with..." feature](/data-design/avo-tracking-plan/properties#replacing-a-property) in the context menu of the property modal
 - **If the properties should not be merged**: Provide unique name and descriptions to better differentiate between these properties in the tracking plan
 
 ## What's next?

--- a/pages/publishing/publishing/amplitude-govern.mdx
+++ b/pages/publishing/publishing/amplitude-govern.mdx
@@ -9,7 +9,7 @@ import {Callout} from 'nextra/components'
 ## Introduction
 
 
-The integration to [Amplitude Govern](https://amplitude.com/govern) allows for your Tracking Plan to be published into Amplitude Govern whenever a branch has been merged. You can also manually trigger a publish by clicking the "Publish to Govern" button on the integration screen or download a CSV file on the Amplitude Govern format, which you can manually import into Govern. The events to be published can be [filtered by Sources, Destinations and Tags](/workspace/tracking-plan/publishing#filtering-events-for-publishing).
+The integration to [Amplitude Govern](https://amplitude.com/govern) allows for your Tracking Plan to be published into Amplitude Govern whenever a branch has been merged. You can also manually trigger a publish by clicking the "Publish to Govern" button on the integration screen or download a CSV file on the Amplitude Govern format, which you can manually import into Govern. The events to be published can be [filtered by Sources, Destinations and Tags](/publishing/publishing/overview#filtering-events-for-publishing).
 
 ## Configure the Govern integration
 
@@ -44,7 +44,7 @@ Here's how events, properties and categories are mapped from Avo to Govern:
 - **Is array**: `true` if the "list" checkbox is checked on the property in Avo
 - **Is required**: `true` if the property is marked as "Always sent" in Avo
 - **Description**: The property description as defined in Avo
-- **Enum values**: If the property is of type string, and the ["property matches..." rule](/workspace/tracking-plan/properties#a-nameproperty-enumsa-enumeration-of-allowed-string-values) is applied in Avo, the allowed values are provided here
+- **Enum values**: If the property is of type string, and the ["property matches..." rule](/data-design/avo-tracking-plan/properties#enumeration-of-allowed-string-values) is applied in Avo, the allowed values are provided here
 
 #### Category
 

--- a/pages/publishing/publishing/overview.mdx
+++ b/pages/publishing/publishing/overview.mdx
@@ -77,7 +77,7 @@ Then you can select the type of integration you want to create and give it a nam
 
 ![Creating a new Publishing Integration](/images/workspace/integrations/create-integration.png)
 
-Note that the publishing integrations are independent of the destinations defined in the "Sources" tab. However the publishing integration can use those destinations to filter which events should be included in the publishing integration. See more below in [Filtering events for publishing](/workspace/tracking-plan/publishing#filtering-events-for-publishing)
+Note that the publishing integrations are independent of the destinations defined in the "Sources" tab. However the publishing integration can use those destinations to filter which events should be included in the publishing integration. See more below in [Filtering events for publishing](/publishing/publishing/overview#filtering-events-for-publishing)
 .
 
 ### Configure Auto publishing
@@ -106,5 +106,5 @@ What does the "lowest common denominator" mean?
 - If the property is "Sometimes sent" on one or more sources being published, the property presence is set to "Sometimes sent" (optional)
 - If property is "Never sent" on all sources being published, the property is not included in the publishing
 
-You can learn more on [configuring when Properties are required or optional here](/workspace/tracking-plan/properties#a-nameproperty-presence-configurationa-configuring-when-properties-are-required-or-optional)
+You can learn more on [configuring when Properties are required or optional here](/data-design/avo-tracking-plan/properties#configuring-when-properties-are-required-or-optional)
 .

--- a/pages/reference/avo-codegen/anonymous-user-id.mdx
+++ b/pages/reference/avo-codegen/anonymous-user-id.mdx
@@ -13,7 +13,7 @@ You don't need to do additional actions for this logic to work on the client sid
 Client side Analytics SDKs can store the information about the currently logged in user.
 It makes possible to identify user once and then send all subsequent tracking calls on behalf of the identified user.
 
-To make an Avo function identify a user you add the Identify action to the corresponding Avo event in your tracking plan. [Learn more about the Identify action](/workspace/tracking-plan/events#a-nameidentify-usera-identify-user).
+To make an Avo function identify a user you add the Identify action to the corresponding Avo event in your tracking plan. [Learn more about the Identify action](/data-design/avo-tracking-plan/events#identify-user).
 
 Codegen corresponding to the events with Identify action will require a userId parameter automatically.
 

--- a/pages/reference/avo-codegen/destinations.mdx
+++ b/pages/reference/avo-codegen/destinations.mdx
@@ -16,14 +16,14 @@ To get started using a destination interface you do the following:
 
 ## Destination Interface overview
 
-We will be referencing _[Codegen](/implementation/avo-codegen-overview)_, _[events](/workspace/tracking-plan/events)_, _[actions](/workspace/tracking-plan/events#a-nameactionsa-actions)_ and other Avo concepts in this document. Please read [the Tracking Plan doc ](/workspace/tracking-plan) and subdocs to get familiar with Avo concepts.
+We will be referencing _[Codegen](/implementation/avo-codegen-overview)_, _[events](/data-design/avo-tracking-plan/events)_, _[actions](/data-design/avo-tracking-plan/events#actions)_ and other Avo concepts in this document. Please read [the Tracking Plan doc ](/avo-tracking-plan) and subdocs to get familiar with Avo concepts.
 
 With a destination interface you'll get access to callback methods for all the Avo actions. The Avo generated code triggers the callbacks when corresponding [Codegen](/implementation/avo-codegen-overview) are called.
 
 > Available event actions in Avo
 >
 > The callback methods mirror the Avo Actions you set up for given Avo Event in your tracking plan in your workspace.
-> Learn how to attach actions to events in [the Tracking Plan section](/workspace/tracking-plan/events#actions).
+> Learn how to attach actions to events in [the Tracking Plan section](/data-design/avo-tracking-plan/events#actions).
 
 ### Destination Interface callback methods
 
@@ -39,7 +39,7 @@ With a destination interface you'll get access to callback methods for all the A
   }
   ```
 
-- `logEvent`: All your analytics events are managed in the Tracking Plan in Avo. Each event gets a generated Avo function. Avo events can have a [Log Event action](/workspace/tracking-plan/events#a-namelog-eventa-log-event) attached. This callback is invoked when an Avo function with Log Event action is called.
+- `logEvent`: All your analytics events are managed in the Tracking Plan in Avo. Each event gets a generated Avo function. Avo events can have a [Log Event action](/data-design/avo-tracking-plan/events#log-event) attached. This callback is invoked when an Avo function with Log Event action is called.
   Here you perform the actual event tracking, calling the track/log methods of your analytics destination. Event name and event properties are provided as parameters.
 
   ```pseudocode
@@ -49,7 +49,7 @@ With a destination interface you'll get access to callback methods for all the A
   }
   ```
 
-- `identify`: If you call an Avo Function for an event with the [Identify User action](/workspace/tracking-plan/events#a-nameidentify-usera-identify-user) in the Tracking Plan, this callback will be invoked. When calling an Avo Function that includes the Identify User action you'll need to provide a user ID.
+- `identify`: If you call an Avo Function for an event with the [Identify User action](/data-design/avo-tracking-plan/events#identify-user) in the Tracking Plan, this callback will be invoked. When calling an Avo Function that includes the Identify User action you'll need to provide a user ID.
   The main use cases are signup and login.
   Here you would pass the user ID to the analytics SDK for it to create a new user or attach a session to an existing user.
 
@@ -60,7 +60,7 @@ With a destination interface you'll get access to callback methods for all the A
   }
   ```
 
-- `unidentify`: If you call an Avo Function for an event with the [Unidentify User action](/workspace/tracking-plan/events#a-nameunidentify-usera-unidentify-user) in the Tracking Plan, this callback will be invoked.
+- `unidentify`: If you call an Avo Function for an event with the [Unidentify User action](/data-design/avo-tracking-plan/events#unidentify-user) in the Tracking Plan, this callback will be invoked.
   Here you would call a destination SDK method to detach subsequent actions from the currently identified user.
 
   ```pseudocode
@@ -70,7 +70,7 @@ With a destination interface you'll get access to callback methods for all the A
   }
   ```
 
-- `revenue`: If you call an Avo Function for an event with the [Log Revenue action](/workspace/tracking-plan/events#a-namelog-revenuea-log-revenue) in the Tracking Plan, this callback will be invoked.
+- `revenue`: If you call an Avo Function for an event with the [Log Revenue action](/data-design/avo-tracking-plan/events#log-revenue) in the Tracking Plan, this callback will be invoked.
   Here you would log the revenue to your analytics destination, many of them have a special method to log revenue.
 
   > 💡 Note that if your destination does not support revenue tracking, you can leave this callback empty.
@@ -82,7 +82,7 @@ With a destination interface you'll get access to callback methods for all the A
   }
   ```
 
-- `page`: If you call an Avo Function for an event with the [Log Page View](/workspace/tracking-plan/events#a-namelog-page-viewa-log-page-view) action in the Tracking Plan, this callback will be invoked.
+- `page`: If you call an Avo Function for an event with the [Log Page View](/data-design/avo-tracking-plan/events#log-page-view) action in the Tracking Plan, this callback will be invoked.
   Here you would report navigation to your analytics destination.
 
   > 💡 Note that if your destination does not support page/screen tracking, you can leave this callback empty.
@@ -94,7 +94,7 @@ With a destination interface you'll get access to callback methods for all the A
   }
   ```
 
-- `setUserProperties`: If you call an Avo Function for an event with the [Update User Properties action](/workspace/tracking-plan/events#a-nameupdate-user-propsa-update-user-properties) in the Tracking Plan, this callback will be invoked.
+- `setUserProperties`: If you call an Avo Function for an event with the [Update User Properties action](/data-design/avo-tracking-plan/events#update-user-properties) in the Tracking Plan, this callback will be invoked.
   Here you would attach user properties to the currently identified user in your analytics platform.
 
   > 💡 Note that if your destination does not support user properties / traits tracking, you can leave this callback empty.
@@ -106,7 +106,7 @@ With a destination interface you'll get access to callback methods for all the A
   }
   ```
 
-- `setGroupProperties`: You can update various group properties along with events in the Tracking Plan. If you call an Avo Function for an event with the [Update Groups action](/workspace/tracking-plan/events#update-groups) in the Tracking Plan, this callback is invoked.
+- `setGroupProperties`: You can update various group properties along with events in the Tracking Plan. If you call an Avo Function for an event with the [Update Groups action](/data-design/avo-tracking-plan/events#update-groups) in the Tracking Plan, this callback is invoked.
   Here you would update the properties for specified groups.
 
   > 💡 Note that if your destination does not support groups / accounts property tracking, you can leave this callback empty.
@@ -236,4 +236,4 @@ If you choose Avo to manage your destination, you'll still have to include the d
 - **Associate user with Group**: Avo will associate current user with the specified group when an Avo event with the 'Update Groups' action is triggered.
 - **Update Groups Properties**: Avo will update specified group metadata when an Avo event with the 'Update Groups' action is triggered.
 
-> Learn more about Avo actions and how to attach them to events in [the Tracking Plan section](/workspace/tracking-plan/events#actions).
+> Learn more about Avo actions and how to attach them to events in [the Tracking Plan section](/data-design/avo-tracking-plan/events#actions).

--- a/pages/reference/avo-codegen/programming-languages/csharp.mdx
+++ b/pages/reference/avo-codegen/programming-languages/csharp.mdx
@@ -56,7 +56,7 @@ avo.SignupStart(referral = "direct")
 
 #### Step 4. Verify the implementation
 
-Use the [Implementation status](/workspace/tracking-plan/implementation-status) in your Avo workspace to verify that your implementation is correct.
+Use the [Implementation status](/data-design/avo-tracking-plan/implementation-status) in your Avo workspace to verify that your implementation is correct.
 
 ### Reference
 
@@ -83,7 +83,7 @@ This method will call the `Make(env, apiKey)` callback in all the provided [dest
 `systemProperties`: a number of parameters equal to the number of system properties defined in your Avo workspace.
 The parameters are named the same as system properties, in camelCase, and require corresponding types: string, int, long, float, bool and list.
 
-`IDestination destination`: object, each destination you are sending events to gets a separate parameter in the init function with hooks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/workspace/tracking-plan/events#a-nameactionsa-actions).
+`IDestination destination`: object, each destination you are sending events to gets a separate parameter in the init function with hooks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/data-design/avo-tracking-plan/events#actions).
 
 ```csharp
 interface IDestination {

--- a/pages/reference/avo-codegen/programming-languages/index.mdx
+++ b/pages/reference/avo-codegen/programming-languages/index.mdx
@@ -13,7 +13,7 @@ You invoke Avo Codegen, provide tracking parameters and
 - Eventually Avo sends the data to the destinations it manages and calls the callbacks (called custom destinations) you provided when initializing.
 
 > It's useful to get the overview of the tracking implementation when working on new tracking.
-> You can also get more insights into dev implementation and actual production state of your tracking with [Inspector implementation status](/workspace/tracking-plan/implementation-status#inspector-implementation-status)
+> You can also get more insights into dev implementation and actual production state of your tracking with [Inspector implementation status](/data-design/avo-tracking-plan/implementation-status#inspector-implementation-status)
 
 ### Handling tracking plan changes
 

--- a/pages/reference/avo-codegen/programming-languages/java.mdx
+++ b/pages/reference/avo-codegen/programming-languages/java.mdx
@@ -54,7 +54,7 @@ Avo.signupStart("direct")
 
 #### Step 4. Verify the implementation
 
-Use the [Implementation status](/workspace/tracking-plan/implementation-status) in your Avo workspace and the [Avo Inspector](/implementation/avo-inspector-sdk-reference) to verify that your implementation is correct. If you don't want to use Avo Inspector you can use the [standalone visual debugger](https://github.com/avohq/android-analytics-debugger) in your client applications.
+Use the [Implementation status](/data-design/avo-tracking-plan/implementation-status) in your Avo workspace and the [Avo Inspector](/implementation/avo-inspector-sdk-reference) to verify that your implementation is correct. If you don't want to use Avo Inspector you can use the [standalone visual debugger](https://github.com/avohq/android-analytics-debugger) in your client applications.
 
 ### Reference
 
@@ -99,7 +99,7 @@ This method will call the `Make(env, apiKey)` callback in all the provided [dest
 `systemProperties`: a number of parameters equal to the number of system properties defined in your Avo workspace.
 The parameters are named the same as system properties, in camelCase, and require corresponding types: string, int, long, float, bool or list.
 
-`ICustomDestination destination`: object, each destination you are sending events to gets a separate parameter in the init function with callbacks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each callback in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/workspace/tracking-plan/events#a-nameactionsa-actions).
+`ICustomDestination destination`: object, each destination you are sending events to gets a separate parameter in the init function with callbacks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each callback in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/data-design/avo-tracking-plan/events#actions).
 
 ```java
 public interface ICustomDestination {

--- a/pages/reference/avo-codegen/programming-languages/javascript.mdx
+++ b/pages/reference/avo-codegen/programming-languages/javascript.mdx
@@ -67,7 +67,7 @@ Avo.signupStart({ referral: 'direct' });
 
 #### Step 4. Verify the implementation
 
-Use the [Implementation status](/workspace/tracking-plan/implementation-status) in your Avo workspace and the [visual debuggers](/explore-tracking-plan/start-using-visual-debuggers) to verify that your implementation is correct.
+Use the [Implementation status](/data-design/avo-tracking-plan/implementation-status) in your Avo workspace and the [visual debuggers](/explore-tracking-plan/start-using-visual-debuggers) to verify that your implementation is correct.
 
 ### Reference
 
@@ -100,7 +100,7 @@ This method will call the `make(env, apiKey)` callback in all the provided [dest
 `systemProperties`: an object where each field represents a system property in your tracking plan.
 When you define system properties in your Avo workspace you set name and type - the fields of this object are named the same as system properties, in camelCase, and you should provide corresponding types, can be string, int, long, float, bool, array, object and any.
 
-`destination`: object, each destination you are sending events to gets a separate parameter in the init function with callbacks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/workspace/tracking-plan/events#a-nameactionsa-actions).
+`destination`: object, each destination you are sending events to gets a separate parameter in the init function with callbacks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/data-design/avo-tracking-plan/events#actions).
 
 ```javascript
 {

--- a/pages/reference/avo-codegen/programming-languages/kotlin.mdx
+++ b/pages/reference/avo-codegen/programming-languages/kotlin.mdx
@@ -65,7 +65,7 @@ avo.signupStart(referral = "direct")
 
 #### Step 4. Verify the implementation
 
-Use the [Implementation status](/workspace/tracking-plan/implementation-status) in your Avo workspace and the [Avo Inspector](/implementation/inspector/sdk/android) to verify that your implementation is correct. If you don't want to use Avo Inspector you can use the [standalone visual debugger](https://github.com/avohq/android-analytics-debugger).
+Use the [Implementation status](/data-design/avo-tracking-plan/implementation-status) in your Avo workspace and the [Avo Inspector](/implementation/inspector/sdk/android) to verify that your implementation is correct. If you don't want to use Avo Inspector you can use the [standalone visual debugger](https://github.com/avohq/android-analytics-debugger).
 
 ### Reference
 
@@ -94,7 +94,7 @@ This method will call the `Make(env, apiKey)` callback in all the provided [dest
 `systemProperties`: a number of parameters equal to the number of system properties defined in your Avo workspace.
 The parameters are named the same as system properties, in camelCase, and require corresponding types: string, int, long, float, bool or list.
 
-`destination: ICustomDestination`: object, each destination you are sending events to gets a separate parameter in the init function with callbacks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/workspace/tracking-plan/events#a-nameactionsa-actions).
+`destination: ICustomDestination`: object, each destination you are sending events to gets a separate parameter in the init function with callbacks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/data-design/avo-tracking-plan/events#actions).
 
 ```kotlin
 interface ICustomDestination {

--- a/pages/reference/avo-codegen/programming-languages/objc.mdx
+++ b/pages/reference/avo-codegen/programming-languages/objc.mdx
@@ -61,7 +61,7 @@ You'll be able to call it like this from the generated code
 
 #### Step 4. Verify the implementation
 
-Use the [Implementation status](/workspace/tracking-plan/implementation-status) in your Avo workspace and the [Avo Inspector](/implementation/inspector/sdk/ios) to verify that your implementation is correct. If you don't want to use Avo Inspector you can use the [standalone visual debugger](https://github.com/avohq/ios-analytics-debugger).
+Use the [Implementation status](/data-design/avo-tracking-plan/implementation-status) in your Avo workspace and the [Avo Inspector](/implementation/inspector/sdk/ios) to verify that your implementation is correct. If you don't want to use Avo Inspector you can use the [standalone visual debugger](https://github.com/avohq/ios-analytics-debugger).
 
 ### Reference
 
@@ -88,7 +88,7 @@ This method will call the `makeWithEnv:withApiKey:` callback in all the provided
 `systemProperties`: a number of parameters equal to the number of system properties defined in your Avo workspace.
 The parameters are named the same as system properties, in camelCase, and require corresponding types: string, int, long, float, bool or list.
 
-`(nonnull id<AVOCustomDestination>) destination`: object, each destination you are sending events to gets a separate parameter in the init function with callbacks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/workspace/tracking-plan/events#a-nameactionsa-actions).
+`(nonnull id<AVOCustomDestination>) destination`: object, each destination you are sending events to gets a separate parameter in the init function with callbacks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/data-design/avo-tracking-plan/events#actions).
 
 ```objectivec
 @protocol AVOCustomDestination

--- a/pages/reference/avo-codegen/programming-languages/php.mdx
+++ b/pages/reference/avo-codegen/programming-languages/php.mdx
@@ -60,7 +60,7 @@ Avo::signup_start(array('referral' => 'direct'));
 
 #### Step 4. Verify the implementation
 
-Use the [Implementation status](/workspace/tracking-plan/implementation-status) in your Avo workspace to verify that your implementation is correct.
+Use the [Implementation status](/data-design/avo-tracking-plan/implementation-status) in your Avo workspace to verify that your implementation is correct.
 
 ### Reference
 
@@ -99,7 +99,7 @@ interface LoggerInterface
 }
 ```
 
-- `[destination_instance]`: object, each destination you are sending events to gets a separate parameter in the init function with callbacks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/workspace/tracking-plan/events#a-nameactionsa-actions).
+- `[destination_instance]`: object, each destination you are sending events to gets a separate parameter in the init function with callbacks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/data-design/avo-tracking-plan/events#actions).
 
 #### Destination interface example
 

--- a/pages/reference/avo-codegen/programming-languages/python.mdx
+++ b/pages/reference/avo-codegen/programming-languages/python.mdx
@@ -61,7 +61,7 @@ avo.signup_start(referral = 'direct')
 
 #### Step 4. Verify the implementation
 
-Use the [Implementation status](/workspace/tracking-plan/implementation-status) in your Avo workspace to verify that your implementation is correct.
+Use the [Implementation status](/data-design/avo-tracking-plan/implementation-status) in your Avo workspace to verify that your implementation is correct.
 
 ### Reference
 
@@ -86,7 +86,7 @@ This method will call the `make(env, apiKey)` callback in all the provided [dest
 `system_properties (dict)`: a dictionary containing the system properties that should be sent with every event.
 When you define system properties in your Avo workspace you set name and type - the keys in this dictionary should be the same as system properties, in snake_case, and you should provide corresponding types, can be string, int, long, float, bool and list.
 
-`[destination (object)]`: each destination you are sending events to gets a separate parameter in the init function with hooks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/workspace/tracking-plan/events#a-nameactionsa-actions).
+`[destination (object)]`: each destination you are sending events to gets a separate parameter in the init function with hooks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/data-design/avo-tracking-plan/events#actions).
 
 #### Destination interface example
 

--- a/pages/reference/avo-codegen/programming-languages/reasonml.mdx
+++ b/pages/reference/avo-codegen/programming-languages/reasonml.mdx
@@ -70,7 +70,7 @@ Avo.signupStart(~referral="direct");
 
 #### Step 4. Verify the implementation
 
-Use the [Implementation status](/workspace/tracking-plan/implementation-status) in your Avo workspace and the [visual debuggers](/explore-tracking-plan/start-using-visual-debuggers) to verify that your implementation is correct.
+Use the [Implementation status](/data-design/avo-tracking-plan/implementation-status) in your Avo workspace and the [visual debuggers](/explore-tracking-plan/start-using-visual-debuggers) to verify that your implementation is correct.
 
 ### Reference
 
@@ -104,7 +104,7 @@ This method will call the `make(env, apiKey)` callback in all the provided [dest
 - `amplitudeDestinationName`: optional Js.t, if you use Amplitude destination managed by Avo, this object will be passed to `amplitude.init(apiKey, null, options)` as the third parameter, `options`
 - `segmentDestinationName`: optional Js.t, if you use Segment destination managed by Avo, this object will be passed to `analytics.load(apiKey, options)` as the second parameter, `options`
 
-`destination`: CustomDestination, each destination you are sending events to gets a separate parameter in the init function with hooks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/workspace/tracking-plan/events#a-nameactionsa-actions).
+`destination`: CustomDestination, each destination you are sending events to gets a separate parameter in the init function with hooks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/data-design/avo-tracking-plan/events#actions).
 
 ```reasonml
 {

--- a/pages/reference/avo-codegen/programming-languages/rescript.mdx
+++ b/pages/reference/avo-codegen/programming-languages/rescript.mdx
@@ -66,7 +66,7 @@ Avo.signupStart(~referral="direct");
 
 #### Step 4. Verify the implementation
 
-Use the [Implementation status](/workspace/tracking-plan/implementation-status) in your Avo workspace and the [visual debuggers](/explore-tracking-plan/start-using-visual-debuggers) to verify that your implementation is correct.
+Use the [Implementation status](/data-design/avo-tracking-plan/implementation-status) in your Avo workspace and the [visual debuggers](/explore-tracking-plan/start-using-visual-debuggers) to verify that your implementation is correct.
 
 ### Reference
 
@@ -105,7 +105,7 @@ This method will call the `make(env)` callback in all the provided [destination 
 - `amplitudeDestinationName`: optional Js.t, if you use Amplitude destination managed by Avo, this object will be passed to `amplitude.init(apiKey, null, options)` as the third parameter, `options`
 - `segmentDestinationName`: optional Js.t, if you use Segment destination managed by Avo, this object will be passed to `analytics.load(apiKey, options)` as the second parameter, `options`
 
-`destination`: CustomDestination, each destination you are sending events to gets a separate parameter in the init function with hooks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/workspace/tracking-plan/events#a-nameactionsa-actions).
+`destination`: CustomDestination, each destination you are sending events to gets a separate parameter in the init function with hooks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/data-design/avo-tracking-plan/events#actions).
 
 Custom destination interface format:
 

--- a/pages/reference/avo-codegen/programming-languages/ruby.mdx
+++ b/pages/reference/avo-codegen/programming-languages/ruby.mdx
@@ -60,7 +60,7 @@ Avo.signup_start(referral: 'direct')
 
 #### Step 4. Verify the implementation
 
-Use the [Implementation status](/workspace/tracking-plan/implementation-status) in your Avo workspace to verify that your implementation is correct.
+Use the [Implementation status](/data-design/avo-tracking-plan/implementation-status) in your Avo workspace to verify that your implementation is correct.
 
 ### Reference
 
@@ -80,7 +80,7 @@ This method will call the `make(env, apiKey)` callback in all the provided [dest
 `system_properties (Hash)`: a Hash containing the system properties that should be sent with every event.
 When you define system properties in your Avo workspace you set name and type - the keys in this hash should be the same as system properties, in snake_case, and you should provide corresponding types, can be string, int, long, float, bool and list.
 
-`[destination (object)]`: each destination you are sending events to gets a separate parameter in the init function with callbacks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/workspace/tracking-plan/events#a-nameactionsa-actions).
+`[destination (object)]`: each destination you are sending events to gets a separate parameter in the init function with callbacks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/data-design/avo-tracking-plan/events#actions).
 
 #### Destination interface example
 

--- a/pages/reference/avo-codegen/programming-languages/swift.mdx
+++ b/pages/reference/avo-codegen/programming-languages/swift.mdx
@@ -60,7 +60,7 @@ avo.signupStart(referral: "direct")
 
 #### Step 4. Verify the implementation
 
-Use the [Implementation status](/workspace/tracking-plan/implementation-status) in your Avo workspace and the [Avo Inspector](/implementation/inspector/sdk/ios) to verify that your implementation is correct. If you don't want to use Avo Inspector you can use the [standalone visual debugger](https://github.com/avohq/ios-analytics-debugger).
+Use the [Implementation status](/data-design/avo-tracking-plan/implementation-status) in your Avo workspace and the [Avo Inspector](/implementation/inspector/sdk/ios) to verify that your implementation is correct. If you don't want to use Avo Inspector you can use the [standalone visual debugger](https://github.com/avohq/ios-analytics-debugger).
 
 #### Step 5. Suppress warnings in the Avo files
 
@@ -102,7 +102,7 @@ This method will call the `make(env, apiKey)` callback in all the provided [dest
 `systemProperties`: a number of parameters equal to the number of system properties defined in your Avo workspace.
 The parameters are named the same as system properties, in camelCase, and require corresponding types: string, int, long, float, bool, list, object or any.
 
-`destination: AvoCustomDestination`: object, each destination you are sending events to gets a separate parameter in the init function with callbacks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/workspace/tracking-plan/events#a-nameactionsa-actions).
+`destination: AvoCustomDestination`: object, each destination you are sending events to gets a separate parameter in the init function with callbacks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/data-design/avo-tracking-plan/events#actions).
 
 ```swift
 public protocol AvoCustomDestination {

--- a/pages/reference/avo-codegen/programming-languages/typescript.mdx
+++ b/pages/reference/avo-codegen/programming-languages/typescript.mdx
@@ -67,7 +67,7 @@ Avo.signupStart({ referral: 'direct' });
 
 #### Step 4. Verify the implementation
 
-Use the [Implementation status](/workspace/tracking-plan/implementation-status) in your Avo workspace and the [visual debuggers](/explore-tracking-plan/start-using-visual-debuggers) to verify that your implementation is correct.
+Use the [Implementation status](/data-design/avo-tracking-plan/implementation-status) in your Avo workspace and the [visual debuggers](/explore-tracking-plan/start-using-visual-debuggers) to verify that your implementation is correct.
 
 ### Reference
 
@@ -118,7 +118,7 @@ When you define system properties in your Avo workspace you set name and type - 
 - `amplitudeDestinationName`: optional object, if you use Amplitude destination managed by Avo, this object will be passed to `amplitude.init(apiKey, null, options)` as the third parameter, `options`
 - `segmentDestinationName`: optional object, if you use Segment destination managed by Avo, this object will be passed to `analytics.load(apiKey, options)` as the second parameter, `options`
 
-`destination`: CustomDestination, each destination you are sending events to gets a separate parameter in the init function with hooks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/workspace/tracking-plan/events#a-nameactionsa-actions).
+`destination`: CustomDestination, each destination you are sending events to gets a separate parameter in the init function with hooks that the Avo generated code will trigger, unless you are using the legacy Avo managed destinations. Each method in the destination interface is directly mapped to the Actions attached to each event in Avo. [Learn more about event Actions in this doc](/data-design/avo-tracking-plan/events#actions).
 
 Custom destination interface format:
 

--- a/pages/reference/public-api/export-tracking-plan.mdx
+++ b/pages/reference/public-api/export-tracking-plan.mdx
@@ -19,7 +19,7 @@ https://api.avo.app/workspaces/:workspaceId/branches/:branchId/export/v1
 
 `:workspaceId` is the ID of your workspace. You'll find it in the URL of your avo tab after `/schemas/`. `:branchId` is the ID of the branch you want to export. If you open a branch in Avo you can find it in the URL after `/branches/`. For the main branch simply use `main`. Note that the branch id is not the same as the branch name.
 
-Returns [a Json payload representation of your tracking plan](/workspace/tracking-plan/publishing#payload-format).
+Returns [a Json payload representation of your tracking plan](/publishing/publishing/overview#payload-format).
 
 ### Authentication
 

--- a/pages/workflow/review.mdx
+++ b/pages/workflow/review.mdx
@@ -110,7 +110,7 @@ You can add a comment at the bottom of the review to discuss the overall branch,
 
 _Example: Adding comment to the overall branch_
 
-When you are done with the review, if your workspace has [approval workflows](/workspace/approval-workflows) enabled, you can change the branch status to “Request changes” or “Approve”.
+When you are done with the review, if your workspace has [approval workflows](/data-design/branches/approval-workflows) enabled, you can change the branch status to “Request changes” or “Approve”.
 
 ## What’s next?
 


### PR DESCRIPTION
+ Updates `/workspace` links to point to their current location
+ Remove `#a-name...` anchors and anchor them to the correct place
+ Clean out some redundant spelling ignores
+ Fast-forward old redirects to avoid double redirects
