### PR TITLE
Fix list layout

### DIFF
--- a/pages/inspector/connect-inspector-to-gtm.mdx
+++ b/pages/inspector/connect-inspector-to-gtm.mdx
@@ -51,8 +51,8 @@ The recipe contains the following tags, triggers and variables:
 - Variables
     - Avo Inspector API Key (needs to be populated before initialization)
     - Avo App Name (optionally provide your application name)
-    - Avo Events To Exclude (optionally add event names to ignore)
-    - Avo Properties To Exclude (optionally add property names to ignore)
+    - Avo Events To Exclude (optionally add event names to ignore)
+    - Avo Properties To Exclude (optionally add property names to ignore)
     - gtm.uniqueEventId
 - Built-in Variables 
     - Debug Mode


### PR DESCRIPTION
Used to be like this:

<img width="857" alt="Screenshot 2023-08-22 at 20 29 34" src="https://github.com/avohq/docs/assets/9194227/4b7da984-d595-43e4-bc76-4d31db99c5be">

Now it's like this:

<img width="534" alt="Screenshot 2023-08-22 at 20 30 28" src="https://github.com/avohq/docs/assets/9194227/e733a991-e525-495c-a4a5-80b9fe6438b9">
