### PR TITLE
Use info type for Callouts for a less aggressive look

### DIFF
--- a/pages/audit/branch-audit.mdx
+++ b/pages/audit/branch-audit.mdx
@@ -4,7 +4,7 @@ import { Callout } from 'nextra/components'
 
 _Learn how to use branch audits to identify and resolve issues introduced on branches._
 
-<Callout>Branch Audit is a feature for the _Team_ and _Enterprise_ plans</Callout>
+<Callout type="info" emoji="💡">Branch Audit is a feature for the _Team_ and _Enterprise_ plans</Callout>
 
 The branch audit reviews the changes you have made on your branch and flags issues which are introduced by your changes, such as unexpected naming or inconsistent types — helping you keep your tracking plan clean and consistent.
 
@@ -28,7 +28,7 @@ For Enterprise plans you have the possibility of enforcing that there are no iss
 
 To learn more about the audit rules, see [Avo's tracking plan audit rules](/audit/rules).
 
-<Callout>The branch audit only audits the _branch_. If you want to identify issues in the tracking plan check out the [Tracking Plan Audit](/audit/overview). If you want to identify issues in your current tracking implementation and data streams, check out [Tracking Observability](/inspector/inspector-overview).</Callout>
+<Callout type="info" emoji="💡">The branch audit only audits the _branch_. If you want to identify issues in the tracking plan check out the [Tracking Plan Audit](/audit/overview). If you want to identify issues in your current tracking implementation and data streams, check out [Tracking Observability](/inspector/inspector-overview).</Callout>
 
 ## What's next?
 

--- a/pages/audit/overview.mdx
+++ b/pages/audit/overview.mdx
@@ -12,7 +12,7 @@ Furthermore, all changes on branches are also checked in the [Branch Audit](/aud
 
 To learn more about the audit rules, see [Avo's tracking plan audit rules](/audit/rules).
 
-<Callout>The tracking plan audit only audits the _plan_. If you want to identify issues in your current tracking implementation and data streams, check out [Tracking Observability](/inspector/inspector-overview).</Callout>
+<Callout type="info" emoji="💡">The tracking plan audit only audits the _plan_. If you want to identify issues in your current tracking implementation and data streams, check out [Tracking Observability](/inspector/inspector-overview).</Callout>
 
 ## What's next?
 

--- a/pages/audit/rules.mdx
+++ b/pages/audit/rules.mdx
@@ -30,7 +30,7 @@ Checks if any two event names in the tracking plan conflict with each other. For
 Pick the casing that matches the one that is dominant one in your workspace and fix the implementation of those that don't fit your standards. Note that changing your existing tracking might cause issues in downstream tools and metrics. **Make sure to discuss with the consumers of the data before making such change**.
 
 
-<Callout>**Best practice:** Have all event names unique to avoid confusion and conflicts in downstream tools, such as in data warehouses and dashboards.</Callout>
+<Callout type="info" emoji="💡">**Best practice:** Have all event names unique to avoid confusion and conflicts in downstream tools, such as in data warehouses and dashboards.</Callout>
 
 ### Casing of event names is consistent
 
@@ -41,7 +41,7 @@ Checks if the casing of event names in the tracking plan is consistent. For even
 
 
 
-<Callout>**Best practice:** Have all event names defined with consistent casing to increases the usability of the data. If the casing is not consistent the person using the data would not only need to know the event name they are looking for, but also the casing of the event name.</Callout>
+<Callout type="info" emoji="💡">**Best practice:** Have all event names defined with consistent casing to increases the usability of the data. If the casing is not consistent the person using the data would not only need to know the event name they are looking for, but also the casing of the event name.</Callout>
 
 #### How to resolve
 
@@ -51,7 +51,7 @@ Fix the names and implementation of the events that don't fit your standards. No
 
 Checks if all events in the tracking plan have a description.
 
-<Callout>**Best practice:** A well defined event description contains information such as when the event should be sent and why it's being tracked.</Callout>
+<Callout type="info" emoji="💡">**Best practice:** A well defined event description contains information such as when the event should be sent and why it's being tracked.</Callout>
 
 ## Property Rules
 
@@ -77,7 +77,7 @@ Checks if any two property names in the tracking plan conflict with each other. 
 
 Pick the casing that matches the one that is dominant one in your workspace and fix the implementation of those that don't fit your standards. Note that changing your existing tracking might cause issues in downstream tools and metrics. **Make sure to discuss with the consumers of the data before making such change**.
 
-<Callout>**Best practice:** Have all property names unique to avoid confusion and conflicts in downstream tools, such as in data warehouses and dashboards.</Callout>
+<Callout type="info" emoji="💡">**Best practice:** Have all property names unique to avoid confusion and conflicts in downstream tools, such as in data warehouses and dashboards.</Callout>
 
 ### Casing of property names is consistent
 
@@ -90,7 +90,7 @@ Checks if the casing of property names in the tracking plan is consistent. For p
 
 Fix the names and implementation of the properties that don't fit your standards. Note that this will only be fixed for the data going forward, not historical data. Note that changing your existing tracking might cause issues in downstream tools and metrics. **Make sure to discuss with the consumers of the data before making such change**.
 
-<Callout>**Best practice:** Have all property names defined with consistent casing to increases the usability of the data. If the casing is not consistent the person using the data would not only need to know the property name they are looking for, but also the casing of the property name.</Callout>
+<Callout type="info" emoji="💡">**Best practice:** Have all property names defined with consistent casing to increases the usability of the data. If the casing is not consistent the person using the data would not only need to know the property name they are looking for, but also the casing of the property name.</Callout>
 
 ### All properties have defined types
 
@@ -100,7 +100,7 @@ Checks if all properties in the tracking plan have a defined type. Every propert
 
 Assign the intended type for the property and make sure that the tracking implementation matches the assigned type.
 
-<Callout>**Best practice:** Have well defined types for all properties to increase the quality of the tracking implementation. Having well define types is the prerequisite for having your tracking consistent across all products and platforms.</Callout>
+<Callout type="info" emoji="💡">**Best practice:** Have well defined types for all properties to increase the quality of the tracking implementation. Having well define types is the prerequisite for having your tracking consistent across all products and platforms.</Callout>
 
 ### All properties have description
 
@@ -110,7 +110,7 @@ Checks if all properties in the tracking plan have a description.
 
 Add descriptions to all properties to increase the quality of your tracking plan.
 
-<Callout>**Best practice:** A well defined property description contains detailed description of what the property is describing, and how it's value should be fetched.</Callout>
+<Callout type="info" emoji="💡">**Best practice:** A well defined property description contains detailed description of what the property is describing, and how it's value should be fetched.</Callout>
 
 \* These rules can only fail after importing an existing tracking plan to Avo. When editing your Tracking Plan in Avo, Avo prevents you from introducing conflicting events and properties.
 

--- a/pages/data-design/best-practices/global-namespace.mdx
+++ b/pages/data-design/best-practices/global-namespace.mdx
@@ -41,7 +41,7 @@ For example:
 
    For example, the data consumer may be used to `player_id` meaning _"id of the current player"_, but then all of a sudden a new event gets created with `player_id` referring to the opposing player. 🤯 The consequences are not only confusion, but also that the "normal" `player_id` property cannot be added to the new event. With a global namespace for properties, this cannot happen\*.
 
-   <Callout>
+   <Callout type="info" emoji="💡">
      Avo provides workarounds to bypass this, in case you have existing tracking
      that requires support for this. Email support@avo.sh for more info.
    </Callout>

--- a/pages/data-design/best-practices/groups.mdx
+++ b/pages/data-design/best-practices/groups.mdx
@@ -2,7 +2,7 @@ import {Callout} from 'nextra/components'
 
 # Intro to Group analytics
 
-<Callout>**Group analytics** is a terminology used in product analytics tools, that 
+<Callout type="info" emoji="💡">**Group analytics** is a terminology used in product analytics tools, that 
 refers to grouping by unique product concepts other than unique users.</Callout>
 
 The concept of [grouping product analytics by unique _users_](/data-design/avo-tracking-plan/properties#user-properties)

--- a/pages/data-design/guides/object-properties.mdx
+++ b/pages/data-design/guides/object-properties.mdx
@@ -6,7 +6,7 @@ In your Avo Tracking Plan properties can have 5 different types, string, integer
 
 In this guide we'll go through the process of defining an object property, including constraints on its keys and values.
 
-<Callout>
+<Callout type="info" emoji="💡">
   The object type is currently behind a feature flag. Reach out to us if you
   want to start defining object properties in your tracking plan.
 </Callout>
@@ -24,7 +24,7 @@ Click the type dropdown in the property drawer and select "object"
    ![](/images/workspace/tracking-plan/property-add-rule.png)
 
 2. Add the properties you'd like to include in the object
-   <Callout>
+   <Callout type="info" emoji="💡">
      All properties in Avo are shared globally throughout the tracking plan,
      this includes the sub-properties of object properties. You can [learn more
      about the global namespace in Avo in this

--- a/pages/implementation/devs-101.mdx
+++ b/pages/implementation/devs-101.mdx
@@ -41,7 +41,7 @@ Learn more technical details about [Codegen here](/implementation/avo-codegen-te
 
 No. None of your events ever go through Avo servers. They go directly from your devices (whether that's a front-end client or a server) to the analytics destination.
 
-<Callout>
+<Callout type="info" emoji="💡">
   This sometimes called "device mode". With CDPs, you can choose between [_Cloud-mode_ or _Device-mode_](https://segment.com/docs/guides/intro-impl/#connection-modes):
 
   - In _Cloud-mode_, your events go through the CDP servers. Your devices send the events to the CDP cloud (aka the CDP Servers) and the CDP cloud sends them to the analytics destinations.

--- a/pages/implementation/guides/download-or-copy-avo-file-manually.mdx
+++ b/pages/implementation/guides/download-or-copy-avo-file-manually.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components';
 
 # Get Avo Codegen without using Avo CLI
 
-<Callout>
+<Callout type="info" emoji="💡">
   Codegen produces type-safe wrappers around your analytics event tracking
   calls, to make it easier and faster to implement your analytics tracking
   calls. [Read more about Codegen here](/implementation/devs-101).

--- a/pages/publishing/importing.mdx
+++ b/pages/publishing/importing.mdx
@@ -4,7 +4,7 @@ import { Callout } from 'nextra/components';
 
 _Import your tracking plan from various sources to get started quickly_
 
-<Callout>
+<Callout type="info" emoji="💡">
   **Import existing tracking specs into Avo to get started quickly**. We know
   that tracking plans come in all shapes and sizes. If you don't see your format
   below you can try converting your existing spreadsheet to one of our supported
@@ -21,7 +21,7 @@ You can import your [event schemas](#importing-event-schemas), [user properties]
 Import your existing event schemas, aka tracking plan, to get started
 quickly.
 
-<Callout>
+<Callout type="info" emoji="💡">
   When importing events that already exist in Avo, the importer will only import
   new properties, categories and tags for the event. The importer will never
   archive or delete existing events or properties, or remove properties,
@@ -35,7 +35,7 @@ See [supported formats for importing event schemas, aka tracking plans](/publish
 
 ### Import User Properties
 
-<Callout>
+<Callout type="info" emoji="💡">
   **User properties** are helpful to segment behaviors by current state of
   users, as opposed to the state at the time of an event trigger. Read about
   [user property use cases and how they
@@ -46,7 +46,7 @@ See [supported formats for importing user properties](/publishing/importing#user
 
 ### Import Group Properties
 
-<Callout>
+<Callout type="info" emoji="💡">
   **Group analytics** are important for b2b companies and can be useful in many
   other cases. Read about [group analytics use cases and how it
   works](/data-design/best-practices/groups).
@@ -56,7 +56,7 @@ See [supported formats for importing group properties](/publishing/importing#gro
 
 ### Import Name Mapping
 
-<Callout>
+<Callout type="info" emoji="💡">
   **Different names to different destinations:** You might need to send events
   and properties with different names to different destinations if: **_a/ You
   have legacy event structures in specific analytics tools_**, which you can't
@@ -205,7 +205,7 @@ You can learn more about common Tracking Plan spreadsheet formats [on our blog.]
 
 CSV format for importing.
 
-<Callout>
+<Callout type="info" emoji="💡">
   **Optional: Associate user property to events** You can either attach user
   properties to events or import them without them being attached to events. 1.
   If you list events in this import that are not already in your tracking plan,

--- a/pages/publishing/publishing/amplitude-data.mdx
+++ b/pages/publishing/publishing/amplitude-data.mdx
@@ -13,7 +13,7 @@ The integration to [Amplitude Data](https://help.amplitude.com/hc/en-us/categori
 
 ## Configure the Amplitude Data integration
 
-<Callout>
+<Callout type="info" emoji="💡">
 **Note:** Amplitude customers who intend on using the Taxonomy API (which is required for Avo Publishing to Amplitude to work) should reach out to their Amplitude Customer Service Manager or Amplitude Support team. More in [Amplitude's docs](https://www.docs.developers.amplitude.com/analytics/apis/taxonomy-api/).
 </Callout>
 

--- a/pages/publishing/publishing/overview.mdx
+++ b/pages/publishing/publishing/overview.mdx
@@ -8,7 +8,7 @@ _Learn about how to publish your Tracking Plan to analytics platforms and APIs_
 
 ## Why keep schema registries in sync
 
-<Callout>
+<Callout type="info" emoji="💡">
   **Event schemas** are important in many layers of your data stack. Keeping
   schema registries in sync across the stack can be a challenge, especially
   since stakeholders involved vary from non-technical folks with a preference
@@ -28,7 +28,7 @@ Avo allows you to maintain a single source of truth for your schemas and keep
 your schema registries in sync, serving both your technical and non-technical
 stakeholders.
 
-<Callout>
+<Callout type="info" emoji="💡">
   **Push or pull your schemas:** To keep your Avo tracking plan in sync with
   your downstream schema registries you can either **push** your schema from Avo
   via Avo Publishing or **pull** your Avo schema via Avo CLI. We recommend

--- a/pages/reference/avo-codegen/custom-loggers.mdx
+++ b/pages/reference/avo-codegen/custom-loggers.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components';
 
 # Controlling logging in Avo Codegen
 
-<Callout>
+<Callout type="info" emoji="💡">
   Custom loggers are currently only supported in Swift, JavaScript and
   TypeScript. [Reach out to us](/help/troubleshooting) if you want access to
   custom loggers in your programming languages.

--- a/pages/reference/public-api/authentication.mdx
+++ b/pages/reference/public-api/authentication.mdx
@@ -32,7 +32,7 @@ Authenticate with the API:
    curl -H "authorization: Basic <Base64 encoded token>" -X GET https://api.avo.app/workspaces/<WorkspaceId>/branches/<BranchId>/export/v1
    ```
 
-   <Callout>You can find the `<WorkspaceId>` and `<BranchId>` in the URL of your Avo workspace: `https://www.avo.app/schemas/<WorkspaceId>/branches/<BranchId>/`</Callout>
+   <Callout type="info" emoji="💡">You can find the `<WorkspaceId>` and `<BranchId>` in the URL of your Avo workspace: `https://www.avo.app/schemas/<WorkspaceId>/branches/<BranchId>/`</Callout>
 
 ## Creating Service Accounts
 
@@ -42,20 +42,20 @@ Authenticate with the API:
 
 2. Enter a descriptive name for where you'll be using this service account and press the `Generate Secret` button.
 
-   <Callout>
+   <Callout type="info" emoji="💡">
      Only workspace members with Admin access can create service accounts.
    </Callout>
 
 3. Once Avo has generated and securely stored your secret, you get one chance to view it. Copy the secret key and save it securely in your internal systems.
 
-   <Callout>
+   <Callout type="info" emoji="💡">
      Avo postfixes the name with `_sa_[randomId]` so make sure to copy the final
      name
    </Callout>
 
    ![](/images/public-api/create-service-account.png)
 
-   <Callout>
+   <Callout type="info" emoji="💡">
      You will never see the secret key again, so make sure to copy it.
    </Callout>
 
@@ -69,7 +69,7 @@ If for some reason you need to delete your service account, you can do so from t
 
 3. Press `Delete` again in the confirm window that pops up.
 
-   <Callout>
+   <Callout type="info" emoji="💡">
      This action cannot be undone. Once deleted, there is no way to recover the
      service account again. As soon as a service account has been deleted it
      will stop working immediately.


### PR DESCRIPTION
Replaced `<Callout>` with `<Callout type="info" emoji="💡">` in all cases except for one depreciation warning