### PR TITLE
Added a Install inspector callout to some pages

### DIFF
--- a/pages/inspector/add-events-from-inspector.mdx
+++ b/pages/inspector/add-events-from-inspector.mdx
@@ -4,6 +4,10 @@ import { Callout } from 'nextra/components';
 
 Inspector compares ingested events and properties against the tracking plan and detects if any are missing. You can import missing events either in bulk or one by one.
 
+<Callout type="info" emoji="💡">
+  If you have not yet installed Inspector, check out the [Inspector installation overview](/inspector/inspector-installation-overview).
+</Callout>
+
 ## Import events from Inspector events
 
 In the Inspector Events view, the red tracking plan icon will indicate those events seen in your tracking that are not documented in your Avo Tracking Plan. Click the “Add (X) events to tracking plan button” to review them in one go and select which events to import. You can also add them one by one by clicking the “Add” button next to each event.

--- a/pages/inspector/inspector-find-issues.mdx
+++ b/pages/inspector/inspector-find-issues.mdx
@@ -5,6 +5,10 @@ import PageLink, { TwoCol } from '../../components/PageLink';
 
 To find issues that are relevant and/or important to you and your team, you can use filtering to narrow down the issues you want to see and sorting to see them in an order that is helpful to you. Once you have sorted and filtered, you can save that view and set up alerts for when new issues fit the criteria of your view.
 
+<Callout type="info" emoji="💡">
+  If you have not yet installed Inspector, check out the [Inspector installation overview](/inspector/inspector-installation-overview).
+</Callout>
+
 ## Sorting and filtering
 
 The issue table can be sorted by any column. Sort by event volume, issue volume or issue percentage to quickly uncover which issues have the most impact on your data and prioritize accordingly.

--- a/pages/inspector/inspector-fix-issues.mdx
+++ b/pages/inspector/inspector-fix-issues.mdx
@@ -6,6 +6,10 @@ import PageLink, { TwoCol } from '../../components/PageLink';
 
 When you find an issue in Inspector, the problem can due to either tracking implementation or the tracking plan.
 
+<Callout type="info" emoji="💡">
+  If you have not yet installed Inspector, check out the [Inspector installation overview](/inspector/inspector-installation-overview).
+</Callout>
+
 ## Fixing an implementation issue found in Inspector
 
 If the implementation is incorrect according to the tracking plan, such that the data coming in is incorrect but the tracking plan is correct, we recommend the following steps:


### PR DESCRIPTION
We are linking to some pages in our drip campaigns explaining some great inspector feature. But it's not obvious where to go if you haven't installed inspector. So adding that to 3 pages.