### PR TITLE
Add Viewer role to docs

### DIFF
--- a/pages/data-design/collaboration/members.mdx
+++ b/pages/data-design/collaboration/members.mdx
@@ -27,17 +27,25 @@ On the Team and Enterprise plans you can limit editor edits to just branches, re
 
 ![The protected main branch toggle](/images/workspace/members/protectedMainBranch.png)
 
-### View Only
+### Viewer
 
-Members with the _View Only_ role can access your workspace but cannot make any modifications and can not access workspace settings including the members and settings modal, audit log or billing page. Additionally, _View Only_ users don't have access to pull Avo Codegen with the Avo CLI. Assign the _View Only_ role to a member when you want to allow them to view your tracking plan but don't want them to be able to make changes. All new plans can add an unlimited amount of _View Only_ users.
+Members with the _Viewer_ role can access your workspace and comment, but cannot make any modifications and can not access workspace settings including the members and settings modal, audit log or billing page. Additionally, _Viewers_ users don't have access to pull Avo Codegen with the Avo CLI. Assign the _Viewer_ role to a member when you want to allow them to view your tracking plan but don't want them to be able to make changes. All new plans can add an unlimited amount of _Viewer_ users.
 
-### Comment Only
-
-Members with a _Comment Only_ role have the same limitations as the _View Only_ role but can comment on events, properties, branches and more. The _Comment Only_ role is available on plans with extended collaboration, [see more](https://www.avo.app/pricing).
 
 ### Billing Only
 
 Members with a _Billing Only_ role can only access the Billing page of the workspace. They can update payment methods and sign up for new subscriptions.
+
+### Legacy Roles
+
+#### View Only (Legacy)
+
+Members with the _View Only_ role can access your workspace but cannot make any modifications and can not access workspace settings including the members and settings modal, audit log or billing page. Additionally, _View Only_ users don't have access to pull Avo Codegen with the Avo CLI. Assign the _View Only_ role to a member when you want to allow them to view your tracking plan but don't want them to be able to make changes. All new plans can add an unlimited amount of _View Only_ users.
+
+#### Comment Only (Legacy)
+
+Members with a _Comment Only_ role have the same limitations as the _View Only_ role but can comment on events, properties, branches and more. The _Comment Only_ role is available on plans with extended collaboration, [see more](https://www.avo.app/pricing).
+
 
 ## What's next?
 

--- a/pages/data-design/collaboration/members.mdx
+++ b/pages/data-design/collaboration/members.mdx
@@ -29,7 +29,7 @@ On the Team and Enterprise plans you can limit editor edits to just branches, re
 
 ### Viewer
 
-Members with the _Viewer_ role can access your workspace and comment, but cannot make any modifications and can not access workspace settings including the members and settings modal, audit log or billing page. Additionally, _Viewers_ users don't have access to pull Avo Codegen with the Avo CLI. Assign the _Viewer_ role to a member when you want to allow them to view your tracking plan but don't want them to be able to make changes. All new plans can add an unlimited amount of _Viewer_ users.
+Members with the _Viewer_ role can access your workspace and comment, but cannot make any modifications and can not access workspace settings including the members and settings modal, audit log or billing page. Additionally, _Viewer_ users don't have access to pull Avo Codegen with the Avo CLI. Assign the _Viewer_ role to a member when you want to allow them to view your tracking plan but don't want them to be able to make changes. All new plans can add an unlimited amount of _Viewer_ users.
 
 
 ### Billing Only


### PR DESCRIPTION
Mark View-only and Comment-only roles as legacy, and include docs for Viewer role