### PR TITLE
Replacing "Triggers" with "Variants" in callout fix

### DIFF
--- a/pages/data-design/avo-tracking-plan/event-variants.mdx
+++ b/pages/data-design/avo-tracking-plan/event-variants.mdx
@@ -10,7 +10,7 @@ Some of the advantages that event variants bring are:
 - simplifying the implementation of Codegen
 
 <Callout type="info" emoji="💡">
-  Note that Event Triggers are available on the Team and Enterprise plans.
+  Note that Event Variants are available on the Team and Enterprise plans.
 </Callout>
 
 ## Introduction


### PR DESCRIPTION
Quick fix to replace "Triggers" with "Variants" on Event Variants page 