### PR TITLE
Replace page with logPage in JS Codegen

### DIFF
--- a/pages/reference/avo-codegen/destinations.mdx
+++ b/pages/reference/avo-codegen/destinations.mdx
@@ -88,7 +88,7 @@ With a destination interface you'll get access to callback methods for all the A
   > 💡 Note that if your destination does not support page/screen tracking, you can leave this callback empty.
 
   ```pseudocode
-  page(pageName, eventProperties) {
+  logPage(pageName, eventProperties) {
     // Log page/screen view in your destination, if your destination supports it
     analytics.page(pageName, eventProperties)
   }

--- a/pages/reference/avo-codegen/programming-languages/javascript.mdx
+++ b/pages/reference/avo-codegen/programming-languages/javascript.mdx
@@ -151,7 +151,7 @@ const mixpanelDestinationInterface = {
   revenue: function (amount, eventProperties) {
     mixpanel.people.track_charge(amount, eventProperties);
   },
-  page: function (pageName, eventProperties) {
+  logPage: function (pageName, eventProperties) {
     // Note: In this example the Mixpanel SDK does not provide a native method for page or screen tracking, so we send an event instead. Other SDKs may have a dedicated page tracking method.
     mixpanel.track(
       'Page Viewed',
@@ -223,7 +223,7 @@ var googleAnalyticsDestinationInterface = {
   revenue: function (amount, eventProperties) {
     gtag('event', 'purchase', { ...eventProperties, amount });
   },
-  page: function (screenName, eventProperties) {
+  logPage: function (screenName, eventProperties) {
     gtag('event', 'screen_view', {
       ...eventProperties,
       screen_name: screenName,
@@ -275,7 +275,7 @@ var mixpanelDestinationInterface = {
   revenue: function (amount, eventProperties) {
     mixpanel.getPeople().trackCharge(amount, eventProperties);
   },
-  page: function (pageName, eventProperties) {
+  logPage: function (pageName, eventProperties) {
     // Note: Mixpanel does not provide a native method for page or screen tracking, so we send an event instead. Other SDKs may have a dedicated page tracking method.
     mixpanel.track(
       'Page Viewed',


### PR DESCRIPTION
For better comparability with the Avo TypeScript Codegen we're re-naming the page call in JavaScript to logPage. This allows users to migrate and re-use a destination interface between these two languages and without risking broken analytics. Note that Codegen still support the old page call on JavaScript so no users will need to make any changes to their existing destination interfaces—they will continue to work just as well as they've ever done.