### PR TITLE
Enable the code block copy button by default

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,7 @@ const nextConfig = {
 const withNextra = nextra({
   theme: 'nextra-theme-docs',
   themeConfig: './theme.config.tsx',
+  defaultShowCopyCode: true,
 });
 
 export default withNextra(nextConfig);


### PR DESCRIPTION
All code blocks should now have the copy button in the top-right corner, unless they include `copy=false` 