### PR TITLE
Update documentation for Export API

### DIFF
--- a/pages/publishing/exporting.mdx
+++ b/pages/publishing/exporting.mdx
@@ -39,7 +39,7 @@ curl -H "authorization: Basic <Base64 encoded token>" \
 - **Quality assurance**: Validate implementations against the latest schema
 - **Custom tooling**: Build internal tools that work with your tracking plan data
 
-👉 **[View complete Export API documentation](/reference/public-api/export-tracking-plan)** for authentication, parameters, and response examples.
+**[View complete Export API documentation](/reference/public-api/export-tracking-plan)** for authentication, parameters, and response examples.
 
 ## Automated Webhook export
 

--- a/pages/publishing/exporting.mdx
+++ b/pages/publishing/exporting.mdx
@@ -14,6 +14,33 @@ To export your tracking plan Schema:
 
    ![](/images/workspace/export-modal.png)
 
+## Programmatic export with the Export API
+
+Use the **Export API** to programmatically export your tracking plan as JSON Schema from any branch. This is ideal for automation, CI/CD pipelines, or integrating with external tools.
+
+### Quick Start
+
+```sh
+curl -H "authorization: Basic <Base64 encoded token>" \
+  -X GET https://api.avo.app/workspaces/:workspaceId/branches/main/export/v1
+```
+
+### Key Features
+
+- **Export any branch**: Export from main or feature branches
+- **JSON Schema format**: Structured data perfect for automation
+- **Rate limited**: 1 request per second per service account
+- **Gzipped responses**: For faster data delivery on large tracking plans
+
+### Use Cases
+
+- **Automated documentation**: Generate documentation from your tracking plan
+- **Data pipeline integration**: Sync tracking plan changes with downstream systems
+- **Quality assurance**: Validate implementations against the latest schema
+- **Custom tooling**: Build internal tools that work with your tracking plan data
+
+👉 **[View complete Export API documentation](/reference/public-api/export-tracking-plan)** for authentication, parameters, and response examples.
+
 ## Automated Webhook export
 
 [Publishing integrations](/publishing/publishing/overview) can be used for exporting your tracking plan, either one of, or a recurring


### PR DESCRIPTION
The Avo exporting documentation in `pages/publishing/exporting.mdx` was updated to highlight the new Export API.

A new section, "Programmatic export with the Export API," was added:
*   Positioned between the "Manual export in the Avo Dashboard" and "Automated Webhook export" sections to establish a logical flow from UI-based to API-based to automated exports.
*   Introduces the Export API for programmatic access to tracking plan schemas.
*   Includes a "Quick Start" `curl` example for immediate testing.
*   Outlines "Key Features" such as branch support, JSON Schema format, rate limiting, and gzipped responses.
*   Provides "Use Cases" like automated documentation, data pipeline integration, and QA validation.
*   Concludes with a direct link to the comprehensive Export API documentation at `/reference/public-api/export-tracking-plan`.

This update enhances the discoverability and understanding of the Export API as a modern, automation-friendly export option.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209281675778184