### PR TITLE
Remove outdated property bundle callout

### DIFF
--- a/pages/data-design/avo-tracking-plan/properties.mdx
+++ b/pages/data-design/avo-tracking-plan/properties.mdx
@@ -139,12 +139,6 @@ An example event property bundle could be "Product" containing the following pro
 - Product Price
 - Product Quantity
 
-<Callout type="info" emoji="💡">
-  A property can only belong to a single bundle. That's to avoid a conflict
-  between bundles when using Avo Codegen. Properties in multiple bundles is 
-  available in a closed beta - please reach out to us for access.
-</Callout>
-
 ## Property types and constraints
 
 In the property view for event, user and system properties you need to define the type of the values allowed for the property. That definition is used to validate the property.


### PR DESCRIPTION
Remove outdated callout stating 'A property can only belong to a single bundle' from documentation.

---

[Slack Thread](https://avosh.slack.com/archives/C47TD0Q0M/p1752835605467169?thread_ts=1752835605.467169&cid=C47TD0Q0M)