### PR TITLE
Added coming soon action for push to datalayer.

### DIFF
--- a/pages/data-design/avo-tracking-plan/events.mdx
+++ b/pages/data-design/avo-tracking-plan/events.mdx
@@ -183,6 +183,7 @@ Below is a list of possible actions, followed by a more detailed overview of eac
 7. [Update Groups](#update-groups): associates users with
    groups and/or updates group properties. Adding users to groups will link them
    in all subsequent calls.
+8. [Push to Data Layer](#push-to-data-layer) *(coming soon)*: pushes data to the data layer when this event is sent.
 
 #### Log Event
 
@@ -350,3 +351,10 @@ property](https://segment.com/docs/spec/page/) with the prefix "Segment: ".
 - Segment: Page Name
 
 Calls either page or screen (depending on your apps platform) with the Page Name property and then call track. If you want to only log a page view, not an event, you can remove the Log Event action from the event.
+
+#### Push to Data Layer (coming soon)
+
+Add the Push to Data Layer action to push data to the data layer when this event is sent.
+
+While it's not yet supported, you can use the "Update User Properties" action to signify that the event is pushing data to the data layer.
+

--- a/pages/data-design/avo-tracking-plan/events.mdx
+++ b/pages/data-design/avo-tracking-plan/events.mdx
@@ -183,7 +183,7 @@ Below is a list of possible actions, followed by a more detailed overview of eac
 7. [Update Groups](#update-groups): associates users with
    groups and/or updates group properties. Adding users to groups will link them
    in all subsequent calls.
-8. [Push to Data Layer](#push-to-data-layer) *(coming soon)*: pushes data to the data layer when this event is sent.
+8. [Push to Data Layer](#push-to-data-layer-coming-soon) *(coming soon)*: pushes data to the data layer when this event is sent.
 
 #### Log Event
 

--- a/pages/data-design/guides/avo-as-solutions-design-document.mdx
+++ b/pages/data-design/guides/avo-as-solutions-design-document.mdx
@@ -56,9 +56,9 @@ In Avo, both the data layer push and the Adobe Analytics event are defined as ev
 
 | Adobe Analytics term | AppMeasurement code call | Web SDK (alloy) code call | Avo term | Avo Action | Purpose |
 | ----- | ----- | ----- | ----- | ----- | ----- |
-| **Data Layer Push** | `adobeDatalayer`<br/>`.push()` | `adobeDatalayer`<br/>`.push()` or `sendEvent` | Event | Push to Data Layer | Populates the data layer with variables. |
-| **Page Event** | `s.t()` | `sendEvent` with `{"eventType": "web.webpagedetails`<br/>`.pageViews"}` | Event | Log Page View | Tracks page loads, increments page view counts, and populates page-related dimensions. |
-| **Custom Link** | `s.tl()` | `sendEvent` with `{"eventType": "commerce.action"}` | Event | Log Event | Tracks events that appear as metrics in Adobe reports, such as purchases, sign-ups, or downloads. |
+| **Data Layer Push** | `adobeDatalayer`<br/>`.push()` | `adobeDatalayer`<br/>`.push()` or `sendEvent` | Event | [Push to Data Layer](/data-design/avo-tracking-plan/events#push-to-data-layer-coming-soon) | Populates the data layer with variables. |
+| **Page Event** | `s.t()` | `sendEvent` with `{"eventType": "web.webpagedetails`<br/>`.pageViews"}` | Event | [Log Page View](/data-design/avo-tracking-plan/events#log-page-view) | Tracks page loads, increments page view counts, and populates page-related dimensions. |
+| **Custom Link** | `s.tl()` | `sendEvent` with `{"eventType": "commerce.action"}` | Event | [Log Event](/data-design/avo-tracking-plan/events#log-event) | Tracks events that appear as metrics in Adobe reports, such as purchases, sign-ups, or downloads. |
 
 *or a more specific action string your team standardizes for your Adobe Analytics implementation
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a "Push to Data Layer" (coming soon) action in Events docs and links Adobe SDD guide actions to the corresponding Events sections.
> 
> - **Docs: Events** (`pages/data-design/avo-tracking-plan/events.mdx`)
>   - Add new supported action: `Push to Data Layer` (coming soon) to actions list.
>   - New section: `Push to Data Layer (coming soon)` with brief guidance and interim use of `Update User Properties`.
> - **Docs: Adobe SDD Guide** (`pages/data-design/guides/avo-as-solutions-design-document.mdx`)
>   - Update actions table to link `Push to Data Layer`, `Log Page View`, and `Log Event` to their anchors in Events docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9ca852ff59507713f1fc7495cdafdc4f58f9b0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->