### PR TITLE
Update Avo MCP docs from alpha to beta

### DIFF
--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -1,11 +1,11 @@
 import { Callout } from 'nextra/components'
 
-# Avo MCP (Alpha)
+# Avo MCP (Beta)
 
 The Avo MCP (Model Context Protocol) server exposes your Avo tracking plan to AI coding assistants. With it, tools like Claude, ChatGPT, Cursor, Codex, and other MCP-compatible clients can read your tracking plan, explore branches, and generate correct analytics instrumentation — without you having to copy-paste event specs into the chat.
 
 <Callout type="warning" emoji="🚧">
-  The Avo MCP is currently in **alpha** and is read-only. We are actively working on write functionality. [Let us know what write capabilities you'd like to see](mailto:support@avo.app) — your feedback shapes what we build next.
+  The Avo MCP is currently in **beta** and is read-only. We are actively working on write functionality. [Let us know what write capabilities you'd like to see](mailto:support@avo.app) — your feedback shapes what we build next.
 </Callout>
 
 What you can do with the Avo MCP:


### PR DESCRIPTION
## Summary
- Update the Avo MCP documentation to reflect the move from alpha to beta
- Changes the title and callout banner in `pages/reference/avo-mcp/overview.mdx`

## Test plan
- [ ] Verify the overview page renders correctly with the updated text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Avo MCP documentation to reflect beta status (previously alpha).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->