### PR TITLE
Update MCP tool docs to reflect current tool inventory

### DIFF
--- a/pages/data-design/avo-tracking-plan/journeys.mdx
+++ b/pages/data-design/avo-tracking-plan/journeys.mdx
@@ -61,13 +61,97 @@ A journey step is composed of the following details:
 
 There are several ways to add a journey step to the canvas:
 
+- **Import from Figma**: Import frames directly from a Figma design file to create steps with images, names, and auto-generated connections — see [Importing steps from Figma](#importing-steps-from-figma)
+- **Drag and drop images**: Drag and drop one or more images directly into the journey builder to create steps with images
 - **Drag from toolbar**: Drag the step icon from the toolbar at the top of the journey builder and drop it onto the canvas
 - **Step mode**: Press `s` to activate step mode, then click anywhere on the canvas to place a step node
-- **Drag and drop images**: Drag and drop one or more images directly into the journey builder to create steps with images
 
 To add an image to an existing journey step, you can drag and drop an image into the journey step or click the placeholder image in the journey step and select an image from your computer.
 
 For a full walkthrough of building journeys on the canvas, see [Creating a journey](#creating-a-journey).
+
+#### Importing steps from Figma
+
+If your designs live in Figma, you can import frames directly into the Journey Builder instead of exporting and re-uploading them manually. Each imported frame becomes a journey step with its image and name. Steps are arranged in a grid that mirrors the spatial order of your Figma frames, and connections between adjacent frames are generated automatically.
+
+This is particularly useful when you are starting a new journey from an existing design file and want to avoid the overhead of manually recreating each screen as a journey step.
+
+<Callout type="info">
+  The Import from Figma feature is available to workspaces with the Figma integration enabled. Contact your workspace admin or Avo support if you don't see the option.
+</Callout>
+
+##### How to import frames from Figma
+
+1. Open a journey in the Journey Builder.
+
+2. Click the **Import from Figma** button in the toolbar at the top of the canvas.
+
+   [Screenshot: Import from Figma button in the Journey Builder toolbar]
+
+3. In the dialog that appears, paste the URL of your Figma design file. Accepted format:
+
+   ```
+   https://www.figma.com/design/{fileKey}/{fileName}?node-id={nodeId}
+   ```
+
+   The URL can point to a specific frame or page within the file — Avo will use it to locate the file and display the available frames.
+
+   [Screenshot: Paste Figma URL dialog]
+
+4. Click **Fetch frames**. Avo retrieves the file metadata from Figma and displays a visual frame picker showing all top-level frames available in the file.
+
+   [Screenshot: Frame picker modal showing Figma frames as thumbnails]
+
+5. Select one or more frames to import. You can select individual frames or use select-all.
+
+6. Click **Import**. Avo downloads each selected frame as an image, uploads it, and creates a journey step for each one.
+
+   [Screenshot: Journey canvas with newly imported steps]
+
+##### What gets created
+
+For each imported frame, Avo creates a journey step with:
+
+- **Image**: A screenshot of the Figma frame
+- **Title**: The frame's name from Figma (e.g. "Checkout – Payment")
+- **Figma source link**: A reference back to the source Figma file and node, so anyone viewing the step can trace it to the original design
+
+Steps are arranged in a grid layout that mirrors the spatial order of the frames in the Figma file. If the journey already contains steps, new steps are placed relative to your current cursor position on the canvas.
+
+##### Auto-generated connections
+
+Frames that were spatially close to each other in the Figma layout — specifically those in the same horizontal row — are automatically connected with edges when imported. This preserves the left-to-right visual flow of your Figma design without manual wiring.
+
+You can add, remove, or adjust connections after import just like any other journey step connection. See [Connections](#connections) for details.
+
+##### After importing
+
+Once your steps are on the canvas, you can:
+
+- Edit step names and descriptions directly in the journey builder
+- Add [image annotations](#image-annotations) to mark where actions occur
+- Add [journey triggers](#journey-triggers) connected to each step
+- Rearrange steps on the canvas to match your preferred layout
+
+Avo does not sync changes made in Figma after the initial import. If your designs change, re-import the updated frames or update the step images manually.
+
+##### Troubleshooting
+
+**"Invalid URL" error when pasting the Figma link**
+
+Make sure the URL follows the format `https://www.figma.com/design/{fileKey}/{fileName}?node-id={nodeId}`. URLs from Figma's prototype view, inspect panel, or other tools (such as FigJam boards) are not supported — use a URL copied directly from a Figma design file.
+
+**No frames appear in the picker**
+
+This can happen if:
+- The selected node is a single component or group rather than a frame or page containing multiple frames
+- The file has no top-level frames on the selected page
+
+Try copying the URL from a higher-level page or frame in the Figma file hierarchy.
+
+**Permission error or "Could not access file"**
+
+Avo can only access Figma files that are publicly accessible or shared with link access. Open the file in Figma, go to **Share**, and make sure **Anyone with the link** can view the file, then try again.
 
 ### Journey triggers
 
@@ -228,7 +312,7 @@ To create a journey, click the "Create Journey" button in the Journeys view. Thi
 There are many possible ways to build journeys and there is no one-size-fits-all solution. But the following workflow is common and recommended:
 
 1. Add a [name](/data-design/avo-tracking-plan/journeys#journey-name) and [description](/data-design/avo-tracking-plan/journeys#journey-description) for the journey
-2. Add [journey steps](/data-design/avo-tracking-plan/journeys#journey-steps) to the canvas by dragging and dropping images, dragging from the toolbar, or pressing `s` to activate step mode
+2. Add [journey steps](/data-design/avo-tracking-plan/journeys#journey-steps) to the canvas using [Import from Figma](#importing-steps-from-figma) to pull frames directly from a design file, or by dragging and dropping images, dragging from the toolbar, or pressing `s` to activate step mode
 3. Order the steps to visualize the user journey and [connect](/data-design/avo-tracking-plan/journeys#connections) them to each other so AI can [generate relevant triggers](/data-design/guides/agentic-data-design#generate-triggers) for each step
 4. Fill in the details for each [journey step](/data-design/avo-tracking-plan/journeys#journey-steps), one-by-one:
     - Add a [name](/data-design/avo-tracking-plan/journeys#journey-name) and [description](/data-design/avo-tracking-plan/journeys#journey-description) for the journey step

--- a/pages/data-design/quick-start.mdx
+++ b/pages/data-design/quick-start.mdx
@@ -72,7 +72,7 @@ When you've created the branch, you have two approaches to design your tracking:
 - Understanding where events should be triggered in the user flow
 - Using [AI-powered suggestions](/data-design/guides/agentic-data-design) to generate triggers and connect to existing events
 
-To create a journey, navigate to the _Journeys_ tab in the left sidebar and click _+ New Journey_. Drag and drop screenshots of your product, add triggers for each user action, and connect them to events in your tracking plan.
+To create a journey, navigate to the _Journeys_ tab in the left sidebar and click _+ New Journey_. [Import from Figma](/data-design/avo-tracking-plan/journeys#importing-steps-from-figma) or drag and drop screenshots of your product, then add triggers for each user action and connect them to events in your tracking plan.
 
 <PageLink
   image={'/docs/images/svg/analyticsmanager.svg'}

--- a/pages/data-design/start-data-design.mdx
+++ b/pages/data-design/start-data-design.mdx
@@ -25,7 +25,7 @@ There are two main approaches to designing your tracking in Avo:
 - Collaborating with product teams who benefit from seeing tracking in visual context
 - You want to use [AI-powered suggestions](/data-design/guides/agentic-data-design) to generate triggers and connect to existing events
 
-With journeys, you drag and drop screenshots, add triggers for user actions, and connect them to events—all in a visual canvas. Learn more in our [Journeys documentation](/data-design/avo-tracking-plan/journeys).
+With journeys, you [Import from Figma](/data-design/avo-tracking-plan/journeys#importing-steps-from-figma) or drag and drop screenshots, add triggers for user actions, and connect them to events—all in a visual canvas. Learn more in our [Journeys documentation](/data-design/avo-tracking-plan/journeys).
 
 ### Direct event and metric creation
 

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -1,11 +1,11 @@
 import { Callout } from 'nextra/components'
 
-# Avo MCP (Alpha)
+# Avo MCP (Beta)
 
 The Avo MCP (Model Context Protocol) server exposes your Avo tracking plan to AI coding assistants. With it, tools like Claude, ChatGPT, Cursor, Codex, and other MCP-compatible clients can read your tracking plan, explore branches, and generate correct analytics instrumentation — without you having to copy-paste event specs into the chat.
 
 <Callout type="warning" emoji="🚧">
-  The Avo MCP is currently in **alpha** and is read-only. We are actively working on write functionality. [Let us know what write capabilities you'd like to see](mailto:support@avo.app) — your feedback shapes what we build next.
+  The Avo MCP is currently in **beta** and is read-only. We are actively working on write functionality. [Let us know what write capabilities you'd like to see](mailto:support@avo.app) — your feedback shapes what we build next.
 </Callout>
 
 What you can do with the Avo MCP:
@@ -35,9 +35,35 @@ claude mcp add avo --transport http https://mcp.avo.app/mcp
   Adding connectors in Claude Desktop requires admin permissions in your organization.
 </Callout>
 
+### Cursor
+
+Add the following to your `mcp.json` file (or `~/.cursor/mcp.json` for global configuration):
+
+```json
+{
+  "mcpServers": {
+    "Avo": {
+      "url": "https://mcp.avo.app/mcp"
+    }
+  }
+}
+```
+
 ### Other MCP clients
 
-Point your client at `https://mcp.avo.app/mcp`. Your client must support both HTTP transport and the browser-based OAuth authorization flow described in the [Authentication](#authentication) section below — the first tool invocation will open a browser window to complete authorization, after which the token is cached. Clients that cannot complete the OAuth flow will not work with the Avo MCP server.
+Add the Avo MCP server to your client's configuration file (commonly `mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "Avo": {
+      "url": "https://mcp.avo.app/mcp"
+    }
+  }
+}
+```
+
+Your client must support both HTTP transport and the browser-based OAuth authorization flow described in the [Authentication](#authentication) section below — the first tool invocation will open a browser window to complete authorization, after which the token is cached. Clients that cannot complete the OAuth flow will not work with the Avo MCP server.
 
 ## Authentication
 
@@ -51,15 +77,9 @@ Most tools are workspace-scoped (`health_check` and `list_workspaces` are global
 
 Call `list_workspaces` to see which Avo workspaces you have access to and find your workspace ID.
 
-**2. Save your workspace**
+**2. Use any tool**
 
-Call `save_workspace` with your workspace ID. This persists the selection in your mcp's configuration so every subsequent tool call uses it automatically — you won't need to pass `workspaceId` each time.
-
-`save_workspace` also returns the exact config snippet or environment variable needed to make the workspace selection permanent across sessions for your specific MCP client.
-
-**3. Use any tool**
-
-Once a workspace is saved, you can browse branches, look up sources, search for events, and get implementation guides directly in your AI session.
+Once you know your workspace ID, you can browse branches, look up sources, search for events, and get implementation guides directly in your AI session. Most tools accept an optional `workspaceId` parameter — if omitted, the server resolves the workspace automatically.
 
 ## Common workflows
 

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components'
 
 # Avo MCP tools reference
 
-All tools (except `health_check` and `list_workspaces`) operate on a workspace. If you have [saved a workspace](/reference/avo-mcp/overview#getting-started), the `workspaceId` parameter is optional — the saved value is used automatically.
+All tools (except `health_check` and `list_workspaces`) operate on a workspace. Most tools support an optional `workspaceId` parameter — if omitted, the server resolves the workspace automatically.
 
 ---
 
@@ -24,26 +24,6 @@ List the Avo workspaces you have access to.
 
 **Returns:** Each workspace's name, ID, and your role in it.
 
-Call this first to find your workspace ID before calling `save_workspace`.
-
----
-
-## `save_workspace`
-
-Persist a workspace selection so all subsequent tool calls use it automatically.
-
-**Parameters:**
-
-| Parameter | Required | Description |
-|---|---|---|
-| `workspaceId` | Yes | The ID of the workspace to save |
-
-**Returns:** Confirmation message plus the exact CLI command or config snippet needed to persist the `WORKSPACE_ID` environment variable in your MCP client config.
-
-<Callout type="info" emoji="💡">
-  When using Claude Code, the workspace ID is persisted to disk automatically. When using other HTTP clients, the workspace ID is not persisted by default — follow the client-specific instructions in the response to set the `WORKSPACE_ID` environment variable and make it permanent across sessions.
-</Callout>
-
 ---
 
 ## `list_branches`
@@ -54,7 +34,7 @@ Browse branches in the workspace.
 
 | Parameter | Required | Description |
 |---|---|---|
-| `workspaceId` | No | Workspace ID (uses saved value if omitted) |
+| `workspaceId` | No | Workspace ID (resolved automatically if omitted) |
 | `branchStatuses` | No | Filter by status. Valid values: `Draft`, `ReadyForReview`, `ChangesRequested`, `Approved`, `Merged`, `Closed`, `Open`. Defaults to open/active branches only. |
 | `pageSize` | No | Number of results per page (1–50, default 25) |
 | `pageToken` | No | Pagination token from a previous response |
@@ -85,7 +65,7 @@ Get full details for a specific branch.
 |---|---|---|
 | `branchId` | One of `branchId` or `branchName` | Branch ID (takes precedence over name) |
 | `branchName` | One of `branchId` or `branchName` | Branch name (case-insensitive; matches open branches) |
-| `workspaceId` | No | Workspace ID (uses saved value if omitted) |
+| `workspaceId` | No | Workspace ID (resolved automatically if omitted) |
 
 **Returns:** Full branch details including:
 - Resolved emails for the creator, all reviewers, and all collaborators
@@ -106,7 +86,7 @@ Get a high-level implementation guide for a branch's tracking plan changes.
 |---|---|---|
 | `branchId` | One of `branchId` or `branchName` | Branch ID |
 | `branchName` | One of `branchId` or `branchName` | Branch name |
-| `workspaceId` | No | Workspace ID (uses saved value if omitted) |
+| `workspaceId` | No | Workspace ID (resolved automatically if omitted) |
 | `sourceId` | No | Filter to a specific source. Use `get_sources` to find source IDs. |
 
 **Returns:**
@@ -134,7 +114,7 @@ Get implementation snippets for all changed events on a branch, for a specific s
 | `sourceId` | Yes | Source ID to get code snippets for. Use `get_sources` to find IDs. |
 | `branchId` | One of `branchId` or `branchName` | Branch ID |
 | `branchName` | One of `branchId` or `branchName` | Branch name |
-| `workspaceId` | No | Workspace ID (uses saved value if omitted) |
+| `workspaceId` | No | Workspace ID (resolved automatically if omitted) |
 
 **Returns:** Per-event implementation snippets, including:
 
@@ -157,13 +137,28 @@ List all sources in the workspace.
 
 | Parameter | Required | Description |
 |---|---|---|
-| `workspaceId` | No | Workspace ID (uses saved value if omitted) |
+| `workspaceId` | No | Workspace ID (resolved automatically if omitted) |
 | `branchId` | No | Branch ID. Defaults to the main branch. |
 | `branchName` | No | Branch name. Defaults to the main branch. |
 
 **Returns:** A table of sources with: source name, programming language, platform, filename hint, and source ID. Sources with no language or platform configured are flagged.
 
 Sources represent the different places in your codebase where tracking fires — for example, "iOS App", "Web App", or "Backend Service". Call this tool to find the `sourceId` before using `get_branch_implementation_guide` or `get_branch_code_snippets`.
+
+---
+
+## `get`
+
+Get details for any tracking plan item by ID.
+
+**Parameters:**
+
+| Parameter | Required | Description |
+|---|---|---|
+| `itemId` | Yes | The ID of the item to retrieve |
+| `workspaceId` | No | Workspace ID (resolved automatically if omitted) |
+
+**Returns:** Full details for the requested item. Supported item types: event, property, metric, category, property bundle, source, destination, group type, and event variant.
 
 ---
 
@@ -176,7 +171,7 @@ Search across the tracking plan using semantic similarity.
 | Parameter | Required | Description |
 |---|---|---|
 | `query` | Yes | Natural language search query |
-| `workspaceId` | No | Workspace ID (uses saved value if omitted) |
+| `workspaceId` | No | Workspace ID (resolved automatically if omitted) |
 | `itemType` | No | Filter by type: `event`, `property`, `metric`, `category`, or `propertyBundle` |
 | `maxResults` | No | Number of results to return (1–20, default 10) |
 

--- a/pages/workflow/plan.mdx
+++ b/pages/workflow/plan.mdx
@@ -73,7 +73,7 @@ To create a journey, navigate to the Journeys tab in the left sidebar and click 
 Here's the recommended workflow:
 
 1. **Add a name and description** for the journey that captures the feature or flow you're tracking
-2. **Add journey steps** by dragging and dropping screenshots or designs directly into the canvas. Order them to visualize the user journey and connect steps to each other so AI can generate more relevant triggers
+2. **Add journey steps** by [importing frames directly from Figma](/data-design/avo-tracking-plan/journeys#importing-steps-from-figma) or by dragging and dropping screenshots onto the canvas. Order them to visualize the user journey and connect steps to each other so AI can generate more relevant triggers
 3. **Annotate images** to highlight specific areas you want to track. Press `t` to activate trigger mode, then click to create a dot annotation (for buttons) or click and drag to create a rectangle annotation (for larger areas like carousels)
 4. **Add triggers** for each user action. Either use [AI-powered suggestions](/data-design/guides/agentic-data-design#generate-journey-triggers) to analyze your screenshots, or create triggers manually by dragging from an annotation or journey step handle
 5. **Connect triggers to events** by linking each trigger to existing events in your tracking plan or creating new ones. AI can [suggest existing events and variants](/data-design/guides/agentic-data-design#reuse-events-and-variants) to help prevent duplicates


### PR DESCRIPTION
## Summary
- Remove `save_workspace` tool (no longer available)
- Add new `get` tool for looking up any tracking plan item by ID (event, property, metric, category, property bundle, source, destination, group type, or event variant)
- Update `workspaceId` parameter descriptions across all tools to reflect automatic resolution instead of referencing saved workspace
- Simplify the "Getting started" flow in the overview from 3 steps to 2

## Test plan
- [ ] Verify the tools reference page renders correctly
- [ ] Confirm all 9 tools are documented
- [ ] Check that no stale `save_workspace` references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import journey steps directly from Figma URLs
  * Nested property conditions in journey triggers
  * Custom Events metric type for flexible metric creation
  * Web SDK lite build for reduced production bundle size
  * Property value validation support for Node.js SDK
  * Webhook publishing filter to send only changed events
  * JSON Schema support for Import/Export APIs

* **Documentation**
  * Updated journey, metrics, and SDK configuration guidance
  * MCP transitioned to Beta with simplified workspace setup

* **Chores**
  * Updated internal dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->