### PR TITLE
Update MCP docs to match live tools

### DIFF
--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -12,6 +12,7 @@ What you can do with the Avo MCP:
 
 - Browse tracking plan branches and see what changed
 - Get implementation guides and code diffs for a specific source
+- Look up details for any tracking plan item — events, properties, metrics, and more
 - Search for events and properties by meaning
 - Discover available sources in your workspace
 
@@ -71,21 +72,15 @@ The MCP server uses OAuth to authenticate you with Avo. The first time you invok
 
 ## Getting started
 
-Most tools are workspace-scoped (`health_check` and `list_workspaces` are global exceptions). The typical first-use sequence is:
+Most tools are workspace-scoped (`health_check` and `list_workspaces` are the exceptions). The typical first-use sequence is:
 
 **1. Discover your workspaces**
 
 Call `list_workspaces` to see which Avo workspaces you have access to and find your workspace ID.
 
-**2. Save your workspace**
+**2. Use any tool**
 
-Call `save_workspace` with your workspace ID. This persists the selection in your mcp's configuration so every subsequent tool call uses it automatically — you won't need to pass `workspaceId` each time.
-
-`save_workspace` also returns the exact config snippet or environment variable needed to make the workspace selection permanent across sessions for your specific MCP client.
-
-**3. Use any tool**
-
-Once a workspace is saved, you can browse branches, look up sources, search for events, and get implementation guides directly in your AI session.
+Pass your `workspaceId` to any tool, or omit it if your MCP client has it configured. You can browse branches, look up sources, search for events, and get implementation guides directly in your AI session.
 
 ## Common workflows
 
@@ -95,6 +90,10 @@ Once a workspace is saved, you can browse branches, look up sources, search for 
 2. `get_sources` — discover available sources (e.g. "iOS App", "Web App")
 3. `get_branch_implementation_guide` with a `branchId` and a `sourceId` — get a summary of what changed and what to implement on a specific branch
 4. `get_branch_code_snippets` with a `branchId` and a `sourceId` — get implementation snippets for each changed event (exact diffs for Codegen sources, pseudocode for manual sources) on a specific branch
+
+### Looking up a tracking plan item
+
+Use `get` with an item ID to fetch full details for any tracking plan item — events, properties, metrics, categories, property bundles, sources, destinations, group types, or event variants. You can find item IDs from `search` results, branch details, or implementation guides.
 
 ### Searching for an event
 

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -34,7 +34,7 @@ Browse branches in the workspace.
 
 | Parameter | Required | Description |
 |---|---|---|
-| `workspaceId` | No | Workspace ID (uses saved value if omitted) |
+| `workspaceId` | No | Workspace ID |
 | `branchStatuses` | No | Filter by status. Valid values: `Draft`, `ReadyForReview`, `ChangesRequested`, `Approved`, `Merged`, `Closed`, `Open`. Defaults to open/active branches only. |
 | `pageSize` | No | Number of results per page (1–50, default 25) |
 | `pageToken` | No | Pagination token from a previous response |
@@ -65,7 +65,7 @@ Get full details for a specific branch.
 |---|---|---|
 | `branchId` | One of `branchId` or `branchName` | Branch ID (takes precedence over name) |
 | `branchName` | One of `branchId` or `branchName` | Branch name (case-insensitive; matches open branches) |
-| `workspaceId` | No | Workspace ID (uses saved value if omitted) |
+| `workspaceId` | No | Workspace ID |
 
 **Returns:** Full branch details including:
 - Resolved emails for the creator, all reviewers, and all collaborators
@@ -86,7 +86,7 @@ Get a high-level implementation guide for a branch's tracking plan changes.
 |---|---|---|
 | `branchId` | One of `branchId` or `branchName` | Branch ID |
 | `branchName` | One of `branchId` or `branchName` | Branch name |
-| `workspaceId` | No | Workspace ID (uses saved value if omitted) |
+| `workspaceId` | No | Workspace ID |
 | `sourceId` | No | Filter to a specific source. Use `get_sources` to find source IDs. |
 
 **Returns:**
@@ -114,7 +114,7 @@ Get implementation snippets for all changed events on a branch, for a specific s
 | `sourceId` | Yes | Source ID to get code snippets for. Use `get_sources` to find IDs. |
 | `branchId` | One of `branchId` or `branchName` | Branch ID |
 | `branchName` | One of `branchId` or `branchName` | Branch name |
-| `workspaceId` | No | Workspace ID (uses saved value if omitted) |
+| `workspaceId` | No | Workspace ID |
 
 **Returns:** Per-event implementation snippets, including:
 
@@ -137,7 +137,7 @@ List all sources in the workspace.
 
 | Parameter | Required | Description |
 |---|---|---|
-| `workspaceId` | No | Workspace ID (uses saved value if omitted) |
+| `workspaceId` | No | Workspace ID |
 | `branchId` | No | Branch ID. Defaults to the main branch. |
 | `branchName` | No | Branch name. Defaults to the main branch. |
 
@@ -171,7 +171,7 @@ Search across the tracking plan using semantic similarity.
 | Parameter | Required | Description |
 |---|---|---|
 | `query` | Yes | Natural language search query |
-| `workspaceId` | No | Workspace ID (uses saved value if omitted) |
+| `workspaceId` | No | Workspace ID |
 | `itemType` | No | Filter by type: `event`, `property`, `metric`, `category`, or `propertyBundle` |
 | `maxResults` | No | Number of results to return (1–20, default 10) |
 

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components'
 
 # Avo MCP tools reference
 
-All tools (except `health_check` and `list_workspaces`) operate on a workspace. If you have [saved a workspace](/reference/avo-mcp/overview#getting-started), the `workspaceId` parameter is optional — the saved value is used automatically.
+All tools (except `health_check` and `list_workspaces`) operate on a workspace. Most tools accept an optional `workspaceId` parameter and support branch resolution by either ID or name.
 
 ---
 
@@ -23,26 +23,6 @@ List the Avo workspaces you have access to.
 **Parameters:** None
 
 **Returns:** Each workspace's name, ID, and your role in it.
-
-Call this first to find your workspace ID before calling `save_workspace`.
-
----
-
-## `save_workspace`
-
-Persist a workspace selection so all subsequent tool calls use it automatically.
-
-**Parameters:**
-
-| Parameter | Required | Description |
-|---|---|---|
-| `workspaceId` | Yes | The ID of the workspace to save |
-
-**Returns:** Confirmation message plus the exact CLI command or config snippet needed to persist the `WORKSPACE_ID` environment variable in your MCP client config.
-
-<Callout type="info" emoji="💡">
-  When using Claude Code, the workspace ID is persisted to disk automatically. When using other HTTP clients, the workspace ID is not persisted by default — follow the client-specific instructions in the response to set the `WORKSPACE_ID` environment variable and make it permanent across sessions.
-</Callout>
 
 ---
 
@@ -164,6 +144,21 @@ List all sources in the workspace.
 **Returns:** A table of sources with: source name, programming language, platform, filename hint, and source ID. Sources with no language or platform configured are flagged.
 
 Sources represent the different places in your codebase where tracking fires — for example, "iOS App", "Web App", or "Backend Service". Call this tool to find the `sourceId` before using `get_branch_implementation_guide` or `get_branch_code_snippets`.
+
+---
+
+## `get`
+
+Get details for any tracking plan item by ID.
+
+**Parameters:**
+
+| Parameter | Required | Description |
+|---|---|---|
+| `itemId` | Yes | The ID of the item to look up |
+| `workspaceId` | No | Workspace ID |
+
+**Returns:** Full details for the item. Supports events, properties, metrics, categories, property bundles, sources, destinations, group types, and event variants.
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove `save_workspace` tool (no longer deployed)
- Add `get` tool for looking up any tracking plan item by ID
- Simplify getting-started flow from 3 steps to 2
- Add "Looking up a tracking plan item" workflow section

## Test plan
- [ ] Verify tool count matches live inventory (9 tools)
- [ ] Check all internal links resolve correctly
- [ ] Review rendered pages on preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import journey steps directly from Figma with automatic connection generation based on frame layout.
  * Look up tracking plan item details (events, properties, metrics, etc.) via MCP tools.

* **Documentation**
  * Updated journey-building guides to include Figma import as a workflow option.
  * Simplified MCP configuration; `workspaceId` is now optional and branch resolution supports ID or name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->