### PR TITLE
docs: spec for Swift & Kotlin codegen API shapes

### DIFF
--- a/planning/swift-codegen-docs-api-shapes/interview-brief.md
+++ b/planning/swift-codegen-docs-api-shapes/interview-brief.md
@@ -1,0 +1,79 @@
+# Interview Brief: swift-codegen-docs-api-shapes
+
+## Feature Name
+`swift-codegen-docs-api-shapes`
+
+## Problem Statement
+The Swift and Kotlin codegen documentation only shows the static/function-per-event pattern (`Avo.appOpened(...)`) and doesn't document the constructor/object-based pattern. Developers evaluating Avo for DI-heavy codebases (e.g., using swift-dependencies) can't discover from the docs that Avo supports a testability-friendly interface. This creates friction during evaluation and risks the impression that Avo's codegen isn't flexible enough.
+
+**Origin:** Intercom support request (Linear: AVO-2599).
+
+## Scope
+
+### In Scope
+- **Swift language reference page** (`pages/reference/avo-codegen/programming-languages/swift.mdx`)
+- **Kotlin language reference page** (`pages/reference/avo-codegen/programming-languages/kotlin.mdx`)
+- **Codegen tech deep dive page** (`pages/implementation/avo-codegen-tech-deep-dive.mdx`)
+- Two API patterns to document:
+  1. **Constructor / object-based pattern** (default for all new workspaces) — lead with this
+  2. **Static pattern** (legacy) — cover in a collapsible/note section
+
+### Out of Scope
+- Library interface / event-typed pattern (internal state, not ready for docs)
+- Swift actor / async-await specifics (behind a separate feature flag, will be covered separately)
+- Other programming languages
+
+## API Patterns to Document
+
+### 1. Constructor / Object-Based Pattern (Default)
+- User instantiates an Avo object via constructor, passing env, system properties, and destination interfaces
+- Event tracking is done via instance methods: `avo.eventName(...)`
+- System properties are stored per-instance
+- This is what all new workspaces get
+
+**Swift example (from platform_tests — keep generic, no actor/async):**
+- File: `/Users/alexverein/code/avo/monorepo2/platform_tests/ios/swift/Buttons/swift6_actor/Buttons/Avo.swift`
+- Usage: `/Users/alexverein/code/avo/monorepo2/platform_tests/ios/swift/Buttons/swift6_actor/Buttons/ViewController.swift`
+- Pattern: `let avo = Avo.initAvo(env: .dev, ...)` then `avo.testEmptyEvent()`
+
+**Kotlin example (from platform_tests):**
+- File: `/Users/alexverein/code/avo/monorepo2/platform_tests/android/kotlin/AndroidKotlin/constructoranalytics/src/main/java/app/avo/constructoranalytics/ConstructorAvo.kt`
+- Usage: `/Users/alexverein/code/avo/monorepo2/platform_tests/android/kotlin/AndroidKotlin/constructoranalytics/src/main/java/app/avo/constructoranalytics/ConstructorActivity.kt`
+- Pattern: `val avo = ConstructorAvoImpl(application, context, AvoEnv.DEV, ...)` then `avo.testEmptyEvent()`
+
+### 2. Static Pattern (Legacy)
+- No object instantiation; initialize via static method
+- Event tracking via static/class methods: `Avo.eventName(...)`
+- System properties stored globally (static/companion object)
+- Legacy — existing workspaces may still use this
+
+**Swift example:**
+- File: `/Users/alexverein/code/avo/monorepo2/platform_tests/ios/swift/Buttons/static_analytics/Buttons/Avo.swift`
+- Pattern: `Avo.initAvo(env: .dev, ...)` then `Avo.testEmptyEvent()`
+
+**Kotlin example:**
+- File: `/Users/alexverein/code/avo/monorepo2/platform_tests/android/kotlin/AndroidKotlin/staticanalytics/src/main/java/app/avo/staticanalytics/StaticAvo.kt`
+- Usage: `/Users/alexverein/code/avo/monorepo2/platform_tests/android/kotlin/AndroidKotlin/staticanalytics/src/main/java/app/avo/staticanalytics/StaticActivity.kt`
+- Pattern: `StaticAvo.initAvoWithInspector(inspector, application, ...)` then `StaticAvo.testEmptyEvent()`
+
+## Documentation Approach
+- **Lead with constructor/object-based** as the default/recommended pattern
+- **Put static pattern in a collapsible/note** labeled as legacy
+- Update existing docs pages in-place (don't create new pages)
+- Highlight DI/testability benefits of the constructor pattern
+- Keep Swift examples generic (no actor/async specifics)
+
+## Files to Modify
+1. `pages/reference/avo-codegen/programming-languages/swift.mdx`
+2. `pages/reference/avo-codegen/programming-languages/kotlin.mdx`
+3. `pages/implementation/avo-codegen-tech-deep-dive.mdx`
+
+## Acceptance Criteria
+- Swift docs page shows the constructor/object-based pattern as the primary approach
+- Swift docs page includes a legacy/collapsible section for the static pattern
+- Kotlin docs page shows the same two patterns with the same structure
+- Tech deep dive page explains the available API shapes
+- A developer evaluating Avo for a DI-heavy codebase can discover the constructor pattern from the docs
+- Code examples are accurate and derived from actual codegen output
+- No mention of the library interface / event-typed pattern
+- No mention of Swift actor / async-await specifics

--- a/planning/swift-codegen-docs-api-shapes/spec-review.md
+++ b/planning/swift-codegen-docs-api-shapes/spec-review.md
@@ -1,0 +1,178 @@
+# Spec Review: Swift & Kotlin Codegen Docs — API Shapes
+
+**Reviewer:** Morticia (Spec QA)
+**Spec:** planning/swift-codegen-docs-api-shapes/spec.md
+**Revision:** 3/5
+**Date:** 2026-04-02
+
+## Engineering Preferences Applied
+- DRY: flagged aggressively
+- Testing: non-negotiable, more > fewer
+- Engineering level: "enough" — not fragile, not over-abstracted
+- Edge cases: err on more, not fewer
+- Style: explicit over clever
+
+---
+
+## Rev 2 Issue Resolution Summary
+
+Rev 3 addressed all 3 Important and all 5 Minor issues from Rev 2:
+- Issue 1 (Important): AC 14 added — Swift Reference Constructor signature fix now in scope. ✓
+- Issue 2 (Important): AC 4 rewritten to name `StaticAvo.initAvoWithInspector(inspector, application, context, AvoEnv.DEV, ...)` explicitly. ✓
+- Issue 5 (Important): AC 15 added — Swift constructor usage example `avo.someEvent()` required after init block. ✓
+- Issue 3 (Minor): AC 16 added — prose must distinguish return types (constructor returns `Avo` instance; static returns void). ✓
+- Issue 4 (Minor): AC 10 expanded with Kotlin constructor minimum alignment requirements and `ConstructorActivity.kt` `avo.track(...)` warning. ✓
+- Issue 6 (Minor): Warning added to AC 10 about the library interface call in `ConstructorActivity.kt`. ✓
+- Issue 7 (Minor): AC 1 and AC 3 now explicitly prohibit static pattern appearing in Step 2. ✓
+- Issue 8 (Minor): AC 10 now anchors `ViewController.swift` to AC 15 as the Swift constructor usage example source. ✓
+
+The spec is substantially stronger than Rev 2. The following issues are new discoveries in Rev 3.
+
+---
+
+## Stage 1: Architecture Review — 23/25
+
+The scope is tight, the file list is correct, the component assignment table is unambiguous, and all three existing files have been read and assessed before implementation work begins. No structural problems. One minor residual issue.
+
+### Issue 1: Tech deep dive Initialization section already partially documents both patterns — the spec does not acknowledge this, creating risk of redundant or conflicting prose
+**Severity:** Minor
+**Location:** Affected Areas table ("avo-codegen-tech-deep-dive.mdx — Update Initialization section to name and explain both API shapes"); the existing `avo-codegen-tech-deep-dive.mdx` lines 62–64
+
+**Problem:** The existing tech deep dive Initialization section already states: "There will either be a static `initAvo` method or a class, named `Avo` by default, with a constructor, depending on your setup." This is not nothing — it acknowledges both patterns exist. The spec's Current State Analysis says the tech deep dive has "No — only static pattern shown" and "Does not name or distinguish the two API shapes." This characterization is incorrect: the page already names both shapes, it just does not identify which is the default for new workspaces and which is legacy. The implementer who reads the spec before reading the file may over-write existing accurate text rather than augmenting it. The spec should correct the Current State Analysis entry for `avo-codegen-tech-deep-dive.mdx` to reflect what is actually there: both patterns are mentioned but not labeled as default vs. legacy.
+
+| Option | Effort | Risk | Impact | Maintenance |
+|--------|--------|------|--------|-------------|
+| A) Update the Current State Analysis row for `avo-codegen-tech-deep-dive.mdx` to: "Both patterns mentioned but not distinguished as default vs. legacy; no prose saying constructor is the default for new workspaces" | Minimal | Low | Medium — prevents over-writing accurate existing text | Low |
+| B) Add a note under the Affected Areas entry: "The Initialization section already mentions both patterns; the change is to add default/legacy labeling, not to rewrite from scratch" | Minimal | Low | Medium — same effect, different placement | Low |
+| C) Do nothing | None | Low — implementer will read the file and see the existing text | — | — |
+
+**Recommendation:** Option A — the Current State Analysis is a key implementation input. Inaccurate "does not name" language, when the file already partially names both shapes, risks unnecessary rewrites that introduce new inaccuracies. Explicit over clever.
+
+---
+
+## Stage 2: Completeness & Quality Review — 22/25
+
+The spec has resolved the major DRY and completeness problems from earlier revisions. The component table, pedagogical note, and resolved ACs are all strong. Two issues remain.
+
+### Issue 2: AC 15 source file citation is technically accurate but practically misleading — `ViewController.swift` does not directly show `Avo.testEmptyEvent()` as a top-level call
+**Severity:** Minor
+**Location:** AC 15 ("Source for the call shape: `static_analytics/Buttons/Controllers/ViewController.swift` (which shows the static event call shape `Avo.testEmptyEvent()`)"); AC 10 ("Swift constructor usage example (AC 15) against `static_analytics/Buttons/Controllers/ViewController.swift`")
+
+**Problem:** The actual `ViewController.swift` (verified by reading the file) does not directly show `Avo.testEmptyEvent()` as a line in any public method — it shows `testAvoEmptyEvent()` (a private wrapper method). The `Avo.testEmptyEvent()` call is inside the body of `testAvoEmptyEvent()` in a `private extension ViewController`. AC 15 says this file "shows the static event call shape `Avo.testEmptyEvent()`" — which is technically true (the call is there) but may confuse an implementer searching the file for a direct prominent usage. An implementer doing a literal text search for `Avo.testEmptyEvent()` will find it inside a private method body, not at the call-site level that would be analogous to the instance form `avo.testEmptyEvent()`. The spec should add a parenthetical locating the call: "inside `testAvoEmptyEvent()` in the `private extension ViewController` section."
+
+| Option | Effort | Risk | Impact | Maintenance |
+|--------|--------|------|--------|-------------|
+| A) Update AC 15: "...`static_analytics/Buttons/Controllers/ViewController.swift` (call is inside `testAvoEmptyEvent()` in the private `ViewController` extension; the static call form is `Avo.testEmptyEvent()`)" | Minimal | Low | Low | Low |
+| B) Point AC 15 to `AppDelegate.swift` instead, which does not contain a usage call — keep ViewController.swift as the correct source despite the indirection | None (status quo) | Low | — | — |
+| C) Do nothing | None | Low — an implementer reading the file will find the call eventually | — | — |
+
+**Recommendation:** Option A — explicit over clever. The engineering preference is explicit over requiring the implementer to infer which line to look at.
+
+### Issue 3: No acceptance criterion covers the Kotlin constructor usage call shape — AC 15 is Swift-only; Kotlin has no analogous requirement
+**Severity:** Important
+**Location:** AC 15 ("The Swift constructor pattern section includes a usage example showing `avo.someEvent()`..."); Acceptance Criteria section (no equivalent for Kotlin)
+
+**Problem:** AC 15 was added in Rev 3 specifically to require a Swift constructor usage example after the init block. The rationale in Rev 2 Issue 5 was: "injecting implies calling it on the stored instance, not just instantiating it... without an example showing `avo.someEvent()`, a reader knows how to create the object but not how to use it." This rationale applies identically to Kotlin. The Kotlin constructor section has no analogous requirement. An implementer who reads AC 3 (Kotlin Step 2) and AC 4 (Kotlin legacy section) and AC 11 (KMP caveat) could produce a Kotlin constructor section showing `val avo = AvoImpl(...)` with a DI callout but no `avo.someEvent()` usage example — satisfying all ACs while leaving the Kotlin DI value proposition only half-demonstrated. `ConstructorActivity.kt` line 115 shows `avo.testEmptyEvent()` as the instance usage call.
+
+| Option | Effort | Risk | Impact | Maintenance |
+|--------|--------|------|--------|-------------|
+| A) Add AC 17: "The Kotlin constructor pattern section includes a usage example showing `avo.testEmptyEvent()` (or an equivalent generic instance method call) following the init code block. Source: `constructoranalytics/ConstructorActivity.kt` line 115. An implementation that shows only the init call and omits the instance usage call is a failing outcome." | Minimal | Low | High — closes a symmetric gap | Low |
+| B) Amend AC 15 to cover both Swift and Kotlin: "Both the Swift and Kotlin constructor pattern sections include a usage example showing the instance method call..." | Minimal | Low | High | Low |
+| C) Do nothing | None | Medium — Kotlin gets a worse DX than Swift; asymmetric documentation | — | — |
+
+**Recommendation:** Option A — a dedicated AC (AC 17) mirrors the structure of AC 15 for Swift and makes the Kotlin requirement unambiguous. Symmetry with AC 15 is preferable to a combined AC because the source files differ.
+
+---
+
+## Stage 3: Test & Edge Case Review — 23/25
+
+The Rev 3 AC improvements (AC 14, AC 15, AC 16) plus the Rev 2 foundation (ACs 1–13) make this one of the most complete AC suites seen in this spec. Almost all user stories now have binary-testable criteria. One remaining gap.
+
+### Issue 4: AC 16 requires prose distinguishing return types on the Swift section — but no analogous requirement exists for the Kotlin section, despite both languages having a static vs. constructor distinction
+**Severity:** Minor
+**Location:** AC 16 ("The prose accompanying the two Swift pattern examples explicitly states that the constructor `initAvo` returns an `Avo` instance... while the static `initAvo` returns void..."); no Kotlin equivalent
+
+**Problem:** AC 16 was added to prevent two nearly-identical-looking Swift code blocks from being presented without explanatory prose. The same risk exists for Kotlin: the constructor pattern shows `val avo = AvoImpl(...)` and the static pattern shows `StaticAvo.initAvoWithInspector(...)` — these use different class names, so the code blocks look more different than the Swift case. However, the return-type distinction (Kotlin constructor returns an `AvoImpl` instance; the static method is a void init) is still worth stating explicitly. Without an AC, a reviewer cannot fail an implementation that omits this prose from the Kotlin section. The asymmetry between AC 16 (Swift-only) and the absence of any equivalent for Kotlin is a gap.
+
+| Option | Effort | Risk | Impact | Maintenance |
+|--------|--------|------|--------|-------------|
+| A) Add a clause to AC 16 extending it to Kotlin: "The same requirement applies to the Kotlin patterns: prose must state that `AvoImpl(...)` returns an instance used for injection while `StaticAvo.initAvoWithInspector(...)` is void and stores state globally" | Minimal | Low | Medium | Low |
+| B) Accept the asymmetry — the Kotlin code blocks use different class names (`AvoImpl` vs `StaticAvo`) which makes the distinction clearer without prose | None | Low | — | — |
+| C) Do nothing | None | Low — the different class names in Kotlin make the distinction visually unmissable compared to Swift | — | — |
+
+**Recommendation:** Option B — the Kotlin case is genuinely different from Swift. In Swift, both patterns call `Avo.initAvo(...)` with the only visible difference being `let avo =`, making prose essential. In Kotlin, `AvoImpl(...)` vs. `StaticAvo.initAvoWithInspector(...)` are visually distinct class names. The risk of an undifferentiated-looking pair of Kotlin code blocks is much lower. Option B is the "engineered enough" choice.
+
+### Issue 5: No edge case addresses what happens when the `<details>` element is inside an MDX component context that doesn't render raw HTML — Nextra/Next.js MDX interop risk is unverified
+**Severity:** Minor
+**Location:** Existing Patterns to Follow section ("`<details>/<summary>` HTML collapsible"); Out of Scope section; AC 13 ("Build passes")
+
+**Problem:** The spec requires `<details>`/`<summary>` native HTML elements in MDX files. The spec cites two existing pages (`start-using-inspector-with-avo-codegen.mdx` and `bulk-editing.mdx`) as precedent. However, the spec does not verify that these patterns render correctly in the current Nextra version used by the docs repo, or that styling is consistent. Native `<details>` in MDX can behave unexpectedly depending on the MDX renderer version (MDX v1 vs v2 vs v3 handle raw HTML differently). AC 13 requires `npm run build` to pass, which will catch compilation errors but not runtime rendering failures (a `<details>` block that compiles but renders as a flat unstyled section). The spec's mitigation — citing existing usage on two pages — is good enough for compilation confidence but not rendering confidence.
+
+| Option | Effort | Risk | Impact | Maintenance |
+|--------|--------|------|--------|-------------|
+| A) Add to AC 13: "The implementer must confirm that the `<details>` element renders correctly in a local dev server (`npm run dev`) by visually verifying the collapsible behavior before submitting" | Minimal | Low | Medium — catches rendering failure that build alone misses | Low |
+| B) Accept that the existing usage on two other pages is sufficient evidence of working `<details>` support in this Nextra configuration | None | Low | — | — |
+| C) Do nothing | None | Low — existing pattern usage is strong evidence | — | — |
+
+**Recommendation:** Option B — the two existing precedent pages in the same repo are strong enough evidence. The "Existing Patterns to Follow" section is doing exactly the job it should: pointing to working examples in the same codebase. Adding a visual verification step to AC 13 would be over-engineering. This is flagged as Minor only because the MDX version interop question is real in general, not because it is likely to be a problem here.
+
+---
+
+## Stage 4: Performance & Feasibility Review — 24/25
+
+All phantom dependency issues from Rev 2 are resolved. All source files exist and have been verified (read directly during this review). The build AC is in place. One very minor observation.
+
+### Issue 6: AC 10 specifies that the Kotlin constructor minimum alignment check requires `application`, `context`, and `AvoEnv.DEV` as "first three positional parameters" — but the actual test file passes `application`, `this`, `AvoEnv.DEV` where `this` is an `Activity`, not a named `context` variable
+**Severity:** Minor
+**Location:** AC 10 ("verifying that `application`, `context`, and `AvoEnv.DEV` appear as the first three positional parameters, consistent with `ConstructorActivity.kt`")
+
+**Problem:** Reading `ConstructorActivity.kt` directly: `ConstructorAvoImpl(application, this, AvoEnv.DEV, ...)` — the second parameter is `this` (an `AppCompatActivity`, which is a `Context`), not a named `context` variable. AC 10 says the reviewer should verify "`application`, `context`, and `AvoEnv.DEV`" appear as the first three positional parameters. An implementer writing `AvoImpl(application, context, AvoEnv.DEV, ...)` with `context` being a named variable is correct and consistent with the source — but the source file literally uses `this` as the context argument. The AC's "consistent with `ConstructorActivity.kt`" language may be read as requiring `this` rather than a `context` variable. This is a minor alignment issue between the AC text and the actual test file. The generic documentation form `AvoImpl(application, context, AvoEnv.DEV, ...)` is more readable and instructive than `AvoImpl(application, this, AvoEnv.DEV, ...)`, so the spec's intent is correct — the wording just needs a small clarification that `context` here means the `Context` argument (which in the test file happens to be `this`).
+
+| Option | Effort | Risk | Impact | Maintenance |
+|--------|--------|------|--------|-------------|
+| A) Update AC 10 to clarify: "...`application`, `context` (the `Context`-typed argument, which is `this` in `ConstructorActivity.kt`), and `AvoEnv.DEV` appear as the first three positional parameters" | Minimal | Low | Low | Low |
+| B) Do nothing — the distinction between `this` and a named `context` variable is obvious to any Kotlin developer | None | Low | — | — |
+| C) Change the minimum alignment requirement to match the test file literally: require `this` (which is technically wrong for documentation) | None | Low | Medium (bad) | — |
+
+**Recommendation:** Option A — one parenthetical removes the ambiguity. It costs nothing and the "explicit over clever" principle applies. An implementer who reads AC 10 and then reads `ConstructorActivity.kt` should not have to make a judgment call about whether `this` satisfies the `context` requirement.
+
+---
+
+## Strengths
+
+- All 8 issues from Rev 2 were addressed substantively, not cosmetically. The AC count grew from 13 to 16 with each addition being meaningful, not padding.
+- AC 14 is the best single addition in Rev 3: it identifies a specific, verifiable discrepancy between the existing `swift.mdx` Reference section (showing `public init(env: AvoEnv, ...)`) and the actual generated API (a static async factory method `Avo.initAvo(...)`), puts it explicitly in scope, and makes "the `public init` form is a failing outcome" a binary test.
+- AC 16 on prose-distinguishing return types is strong. The pedagogical design note is no longer just aspirational — it has a binary AC anchoring it.
+- The warning in AC 10 about `avo.track(ConstructorAvoBase.AvoEvent.TestEmptyEventEvent)` appearing adjacent to `avo.testEmptyEvent()` in `ConstructorActivity.kt` is validated by direct source inspection: line 129 of `ConstructorActivity.kt` is exactly that call, on the line immediately after `avo.testEmptyEvent()`. The spec's explicit guard is correct.
+- The platform test files referenced in Dependencies were verified to exist and to match the spec's descriptions of their content.
+- The Open Questions Resolved section remains the single best structural feature of this spec: every question has a specific file reference and a verbatim code form as the answer.
+
+---
+
+## Summary
+
+| Stage | Score | Top Issue |
+|-------|-------|-----------|
+| Architecture | 23/25 | Current State Analysis incorrectly characterizes the tech deep dive as not naming both patterns — existing text already mentions both |
+| Completeness & Quality | 22/25 | No AC covers the Kotlin constructor usage call shape (`avo.testEmptyEvent()`) — asymmetric with AC 15 for Swift |
+| Test & Edge Cases | 23/25 | AC 16 requires prose distinguishing return types for Swift only; Kotlin has no analogous requirement (though the visual distinction is clearer there) |
+| Performance & Feasibility | 24/25 | AC 10's `context` vs. `this` wording is technically inconsistent with `ConstructorActivity.kt` which passes `this` as the context argument |
+| **Total** | **92/100** | |
+
+**Verdict:** PASS
+**Critical issues:** 0
+**Important issues:** 1
+**Minor issues:** 5
+
+## Recommendation
+
+This spec passes. The one Important issue (Issue 3 — no Kotlin constructor usage call AC) is a real gap but not blocking: a diligent implementer following the symmetric logic of AC 15 and the Kotlin user story would likely add the usage example anyway. Address it in the next revision for cleanliness before PRD generation.
+
+Priority order for optional Rev 4 cleanup:
+1. Add AC 17 for Kotlin constructor usage call shape — `avo.testEmptyEvent()` required after the init block (Issue 3, Important)
+2. Correct the Current State Analysis entry for `avo-codegen-tech-deep-dive.mdx` — it already mentions both patterns, just not labeled (Issue 1, Minor)
+3. Clarify AC 15 source file citation to locate the call inside `testAvoEmptyEvent()` in the private `ViewController` extension (Issue 2, Minor)
+4. Clarify AC 10 `context` vs. `this` wording with a parenthetical (Issue 6, Minor)
+5. Issues 4 and 5 are scored as Minor and the recommendation in both cases is to do nothing — no action needed.
+
+Run `/pugsley swift-codegen-docs-api-shapes` to generate the PRD.

--- a/planning/swift-codegen-docs-api-shapes/spec.md
+++ b/planning/swift-codegen-docs-api-shapes/spec.md
@@ -1,0 +1,256 @@
+# Feature Spec: Swift & Kotlin Codegen Docs — API Shapes
+
+**Feature Name:** `swift-codegen-docs-api-shapes`
+**Created:** 2026-04-02
+**Status:** Draft — Rev 3 (Morticia Rev 2 fixes)
+
+## Problem Statement
+
+The Swift and Kotlin codegen documentation inadequately documents the constructor/object-based pattern (`let avo = Avo.initAvo(...); avo.eventName(...)`). Developers evaluating Avo for dependency-injection-heavy codebases (e.g., using swift-dependencies or Hilt) cannot discover from the docs that Avo supports a testability-friendly interface. This creates friction during the evaluation phase and risks the impression that Avo's codegen is too rigid for modern DI-first architectures.
+
+Origin: Intercom support request (Linear: AVO-2599).
+
+## Current State Analysis
+
+Before scoping implementation work, the actual state of the three files:
+
+### `swift.mdx` Step 2
+
+- **Constructor pattern present?** Yes — "Initialize Avo by creating an object using constructor" with `val avo = Avo(env: .dev, ...)`
+- **Issues:**
+  - `val` keyword is wrong in Swift; should be `let`
+  - Call shape `Avo(...)` differs from actual codegen `Avo.initAvo(...)`
+  - No DI/testability note
+  - No legacy static section
+
+### `swift.mdx` Reference > Constructor
+
+- **Constructor pattern present?** Yes — shows constructor signature
+- **Issues:**
+  - Describes object-based init but does not show the call site pattern or DI use case
+  - **Discrepancy:** The existing Reference > Constructor section (lines ~82–100) shows the signature as `public init(env: AvoEnv, ...)` — a standard Swift initializer signature — but the actual generated call site is `let avo = await Avo.initAvo(env: .dev, ...)` (a static async factory method returning `Avo`). The `public init` signature is inconsistent with the actual API shape confirmed in the platform test files. The implementer must update this Reference signature to reflect the `static func initAvo(...) async -> Avo` factory form. This fix is **in scope** for this revision; see AC 14.
+
+### `kotlin.mdx` Step 2
+
+- **Constructor pattern present?** Yes — with `val avo = AvoImpl(env = AvoEnv.DEV, ...)`
+- **Issues:**
+  - Class name and call shape are correct for a generic workspace
+  - No DI/testability note
+  - No legacy static section
+
+### `kotlin.mdx` Reference > Constructor
+
+- **Constructor pattern present?** Yes
+- **Issues:**
+  - Present and structurally correct
+  - Has a pre-existing `Map<String, *` syntax error (unclosed generic) in the destination interface example — known pre-existing defect, out of scope for this spec, do not worsen it
+
+### `avo-codegen-tech-deep-dive.mdx`
+
+- **Constructor pattern present?** No — only static pattern shown
+- **Issues:** Does not name or distinguish the two API shapes
+
+### Implementation Scope
+
+The work is narrower than "add the constructor pattern from scratch." The priority is:
+
+1. Fix the `val`→`let` keyword and call-shape accuracy in `swift.mdx` Step 2
+2. Add DI/testability callouts on both reference pages
+3. Add legacy static collapsible sections on both reference pages
+4. Update the tech deep dive to explain both shapes
+
+The constructor Reference sections already exist.
+
+## Goals
+
+1. A developer evaluating Avo for a DI-heavy Swift or Kotlin codebase can discover the constructor/object-based pattern from the docs without requiring a support request.
+2. The static/legacy pattern remains documented so existing workspace users are not broken, but it is clearly identified as legacy.
+3. The codegen tech deep dive page accurately describes both available API shapes at the initialization level.
+
+## User Stories Overview
+
+- As a Swift developer adopting a DI framework (e.g., swift-dependencies), I want to see how to instantiate the Avo object and inject it as a dependency so that I know Avo fits my architecture before integrating it.
+- As a Kotlin/Android developer using Hilt or a similar DI container, I want to see the constructor-based Avo initialization pattern so that I can evaluate whether Avo is compatible with my testability approach.
+- As an existing Avo user on the legacy static pattern, I want the static pattern to remain documented so that I do not need to migrate my codebase when updating docs-referenced setup.
+- As a developer reading the codegen tech deep dive, I want to understand what API shapes are available in the generated file so that I know which one applies to my workspace.
+
+## Affected Areas
+
+| Area | Files/Modules | Impact |
+|------|--------------|--------|
+| Swift language reference | `pages/reference/avo-codegen/programming-languages/swift.mdx` | Fix `val`→`let` in Step 2; correct call shape to `Avo.initAvo(...)`; add DI/testability callout; add legacy static collapsible section |
+| Kotlin language reference | `pages/reference/avo-codegen/programming-languages/kotlin.mdx` | Add DI/testability callout; add legacy static collapsible section |
+| Codegen tech deep dive | `pages/implementation/avo-codegen-tech-deep-dive.mdx` | Update Initialization section to name and explain both API shapes |
+
+## Pedagogical Design Note: Making Two Patterns with the Same Method Name Look Distinct
+
+Both patterns call `Avo.initAvo(...)` (Swift) or `AvoImpl(...)` (Kotlin). Without deliberate presentation, the two code blocks will look nearly identical. The documentation must make the distinction unmissable:
+
+- **Swift:** The constructor pattern must show `let avo = Avo.initAvo(env: .dev, ...)` with the return-value capture visually prominent. The static pattern shows `Avo.initAvo(env: .dev, ...)` with no assignment. The prose must call out this difference explicitly: "With the constructor pattern, `initAvo` returns an `Avo` instance that you store and inject. With the static pattern, the return value is discarded and state is stored globally."
+- **Kotlin:** Same approach — `val avo = AvoImpl(...)` vs. the static `Avo.initAvo(...)` call that assigns no instance variable.
+- **Visual hierarchy:** The constructor pattern is the primary section (no collapse). The static pattern is in a `<details>/<summary>` element labelled "Legacy: Static pattern" — its collapsed state reinforces that it is secondary.
+- **The DI callout:** Placing an explicit testability/DI sentence immediately after the constructor example (before the static section) primes the reader with the "why" before they see the "what."
+
+## Existing Patterns to Follow
+
+| Pattern | Where | Why Relevant |
+|---------|-------|-------------|
+| `<Callout type="info">` from nextra/components | `pages/implementation/avo-codegen-tech-deep-dive.mdx` (and many other pages) | Use for DI/testability note on both reference pages |
+| `<details>/<summary>` HTML collapsible | `pages/implementation/guides/start-using-inspector-with-avo-codegen.mdx`, `pages/data-design/guides/bulk-editing.mdx` | Use for the legacy static section; must be closed by default (no `open` attribute) |
+| Code fence with language tag | All reference pages | All code examples use fenced code blocks with language identifiers (`swift`, `kotlin`) |
+
+**Component assignment per location (not optional — implementer must follow this):**
+
+| File | Location | Component to use |
+|------|----------|-----------------|
+| `swift.mdx` | DI/testability benefit note after constructor example | `<Callout type="info">` — requires adding `import { Callout } from 'nextra/components'` to `swift.mdx` |
+| `swift.mdx` | Legacy static section | `<details>/<summary>` (no `open` attribute) |
+| `kotlin.mdx` | DI/testability benefit note after constructor example | `<Callout type="info">` — requires adding `import { Callout } from 'nextra/components'` to `kotlin.mdx` |
+| `kotlin.mdx` | Legacy static section | `<details>/<summary>` (no `open` attribute) |
+| `avo-codegen-tech-deep-dive.mdx` | Both pattern descriptions | `<Callout type="info">` (import already present) |
+
+## Constraints
+
+- **Performance:** No performance impact; changes are documentation-only.
+- **Compatibility:** No new npm dependencies. Native HTML `<details>`/`<summary>` for collapsibles. `Callout` import must be added to `swift.mdx` and `kotlin.mdx`.
+- **Security:** No security implications; documentation change only.
+- **Accuracy:** Code examples must be derived from actual codegen output in the platform test files, not hand-crafted. Examples must remain generic (no test-harness-specific system properties). See the Swift async constraint clarification below.
+
+**Swift async/await constraint (replaces the blanket "no async" rule):**
+
+All Swift constructor test files (`constructor_analytics/Buttons/Managers/AppDelegate.swift`, `constructor_analytics/ButtonsTests/Helpers/AvoHelper.swift`, `swift6_actor/Buttons/ViewController.swift`) use `async/await` — there is no non-async constructor call site in the test suite. The constraint is therefore:
+
+- **Swift constructor example:** May show `await Avo.initAvo(env: .dev, ...)` inside a `Task { }` block, since this matches the actual generated API. The prose must note this is because the constructor is an async method. Alternatively, the example may omit the `Task { }` wrapper and show only the `await Avo.initAvo(...)` call with a prose note that it must be called from an async context.
+- **Swift static example:** Must not contain `await`, `async`, or `actor` keywords. Source: `static_analytics/Buttons/Managers/AppDelegate.swift` — uses `Avo.initAvo(env: .dev, ...)` synchronously.
+- **The actor/async specifics** (Swift 6 strict concurrency, `@MainActor`, actor isolation) remain out of scope and must not appear in the documentation.
+
+## Out of Scope
+
+- Library interface / event-typed pattern (`avo.track(AvoEvent.myEvent)`) — internal, not ready for docs.
+- Swift 6 / actor-based strict concurrency patterns, `@MainActor`, actor isolation — covered separately.
+- Other programming languages (TypeScript, JavaScript, Python, etc.).
+- Migration guide for moving from static to constructor pattern.
+- Changes to any page other than the three listed above.
+- The pre-existing `Map<String, *` syntax error in `kotlin.mdx`'s destination interface example — known pre-existing defect, do not fix or worsen.
+- The pre-existing `######` heading for "Additional arguments" in `kotlin.mdx` after the destination interface section — known structural oddity, do not worsen the heading hierarchy.
+- Error handling for `initAvo` in strict mode: the existing `strict` parameter documentation already covers this; no new content needed.
+
+## Edge Cases
+
+- **Workspace still generates the static pattern:**
+  The `<details>/<summary>` section clearly states it applies to existing/legacy workspaces; no instruction to migrate.
+
+- **Swift async constructor:**
+  The constructor example may include `await` since all constructor-pattern generated files produce an async `initAvo`. The example must be wrapped in `Task { }` or accompanied by a prose note. Actor/Swift 6 specifics are still excluded.
+
+- **Kotlin class name varies by workspace prefix:**
+  The constructor class name is `[WorkspacePrefix]AvoImpl`. For a generic new workspace the prefix is empty → class is `AvoImpl`. The test file uses `ConstructorAvoImpl` because the test workspace is prefixed "Constructor." Documentation must use the generic `AvoImpl` with a note about prefix variation.
+
+- **Kotlin Multiplatform workspaces:**
+  Include a note that `AvoImpl` is the default class name and that KMP beta users may see a different name, mirroring the existing KMP caveat.
+
+- **Developer reads only the Quickstart section:**
+  Step 2 must show the constructor pattern as the default, not the static one.
+
+- **Tech deep-dive references `initAvo` static method:**
+  The existing static example must remain but be labelled as one of two available shapes, with the constructor shape introduced alongside it.
+
+## Acceptance Criteria
+
+- [ ] **AC 1 — Swift Step 2 call shape:** The Swift docs page (`swift.mdx`) Step 2 shows `let avo = Avo.initAvo(env: .dev, ...)` (not `val`, not `Avo(env: .dev, ...)`). The `let` keyword is Swift-correct and the call shape matches the actual generated `Avo.initAvo` factory method. The Step 2 section must not contain a static pattern code block; the static pattern appears only in the Reference section's collapsible `<details>` element. An implementation that shows both patterns in Step 2 is a failing outcome.
+- [ ] **AC 2 — Swift legacy section:** The Swift docs page includes a `<details>` element (without the `open` attribute, so collapsed by default) with a `<summary>` labelled "Legacy: Static pattern" that documents `Avo.initAvo(env: .dev, ...)` (void return, no assignment) and `Avo.eventName(...)` usage.
+- [ ] **AC 3 — Kotlin Step 2:** The Kotlin docs page (`kotlin.mdx`) shows `val avo = AvoImpl(env = AvoEnv.DEV, ...)` as the primary/default approach. The class name `AvoImpl` is used (generic workspace default), with a note that the actual class name matches the workspace prefix. The Step 2 section must not contain a static pattern code block; the static pattern appears only in the Reference section's collapsible `<details>` element. An implementation that shows both patterns in Step 2 is a failing outcome.
+- [ ] **AC 4 — Kotlin legacy section:** The Kotlin docs page includes a `<details>` element (without the `open` attribute, so collapsed by default) with a `<summary>` labelled "Legacy: Static pattern" that documents `StaticAvo.initAvoWithInspector(inspector, application, context, AvoEnv.DEV, ...)` as the static init call shape and `StaticAvo.eventName(...)` as the static event call shape, sourced from `staticanalytics/StaticActivity.kt`. Using `initAvo(...)` (without `WithInspector`) is a failing outcome — the Kotlin static init method is `initAvoWithInspector`.
+- [ ] **AC 5 — Tech deep dive names both shapes and states the correct default:** The tech deep dive page (`avo-codegen-tech-deep-dive.mdx`) Initialization section explicitly states: (a) the constructor/object-based pattern is the default for all new workspaces, and (b) the static pattern applies to existing/legacy workspaces. A reviewer can verify both statements are present and correct — stating the reverse (static as default) is a failing outcome.
+- [ ] **AC 6 — Swift constructor async correctness:** The Swift constructor example either (a) shows `await Avo.initAvo(env: .dev, ...)` inside a `Task { }` block with a prose note explaining it is async, or (b) shows the bare `await Avo.initAvo(...)` call with a note that it must be called from an async context. The example does not contain `actor` keyword or Swift 6 strict concurrency patterns.
+- [ ] **AC 7 — No library interface mention:** No page mentions the library interface / event-typed pattern (`avo.track(AvoEvent...)` or equivalent).
+- [ ] **AC 8 — DI/testability callout on both pages:** Each reference page (`swift.mdx` and `kotlin.mdx`) includes a `<Callout type="info">` immediately following the constructor pattern example that explicitly states the constructor pattern enables dependency injection and names an example DI framework relevant to that language (swift-dependencies for Swift; Hilt for Kotlin).
+- [ ] **AC 9 — Static pattern identified as legacy:** The static pattern sections on both reference pages and the tech deep dive are clearly identified as applying to legacy/existing workspaces and not recommended for new integrations.
+- [ ] **AC 10 — Code example accuracy verification:** The writer confirms each code example against the designated source file before submitting. Specifically: Swift constructor init example against `constructor_analytics/Buttons/Managers/AppDelegate.swift`; Swift constructor usage example (AC 15) against `static_analytics/Buttons/Controllers/ViewController.swift` (which shows the static event call shape `Avo.testEmptyEvent()` — use the analogous instance form `avo.someEvent()` for the constructor usage example); Swift static init example against `static_analytics/Buttons/Managers/AppDelegate.swift`; Swift static usage example against `static_analytics/Buttons/Controllers/ViewController.swift`; Kotlin constructor example against `constructoranalytics/ConstructorActivity.kt` (using `AvoImpl` as the generic name); Kotlin static example against `staticanalytics/StaticActivity.kt`. Each example must compile if the destination interface is provided. For the Kotlin constructor example, the generic example will differ from the workspace-specific test file in class name (`AvoImpl` vs `ConstructorAvoImpl`) and parameter count; accuracy check is limited to verifying that `application`, `context`, and `AvoEnv.DEV` appear as the first three positional parameters, consistent with `ConstructorActivity.kt`, and that at least one system property placeholder or comment is present. **Warning:** `ConstructorActivity.kt` contains both `avo.testEmptyEvent()` (the correct instance method call) and `avo.track(ConstructorAvoBase.AvoEvent.TestEmptyEventEvent)` (the library interface pattern, excluded by AC 7) on adjacent lines. Only the `avo.testEmptyEvent()` form should appear in documentation; the `avo.track(...)` call must not appear. A note in the PR description must confirm which file each example was verified against.
+- [ ] **AC 11 — KMP caveat present:** The Kotlin reference page includes a note that `AvoImpl` is the default class name for new workspaces and that Kotlin Multiplatform (beta) users may see a different class name, consistent with the existing KMP caveat already on the Kotlin page.
+- [ ] **AC 12 — Callout imports added:** `swift.mdx` and `kotlin.mdx` both include `import { Callout } from 'nextra/components'` at the top of the file (or wherever imports are placed in those files).
+- [ ] **AC 13 — Build passes:** The docs site builds without errors after all changes are applied (`npm run build` in the docs repo passes with no compilation errors introduced by this change).
+- [ ] **AC 14 — Swift Reference Constructor signature corrected:** The `swift.mdx` Reference > Constructor section shows the factory method signature as `static func initAvo(...) async -> Avo` (or equivalent accurate form), not `public init(env: AvoEnv, ...)`. The `public init` form is a failing outcome because the actual generated API is a static async factory method, as confirmed by `constructor_analytics/Buttons/Managers/AppDelegate.swift` (which calls `avo = await Avo.initAvo(...)`). The updated signature must be consistent with the `Avo.initAvo(...)` call form mandated by AC 1 and AC 6.
+- [ ] **AC 15 — Swift constructor usage example present:** The Swift constructor pattern section includes a usage example showing `avo.someEvent()` (or an equivalent generic instance method call) following the init code block, demonstrating that the returned `Avo` instance is called to track events via instance methods. An implementation that shows only the init call and omits the instance usage call is a failing outcome. Source for the call shape: `static_analytics/Buttons/Controllers/ViewController.swift` (static usage pattern `Avo.testEmptyEvent()` — use the analogous instance form `avo.testEmptyEvent()` for the constructor section).
+- [ ] **AC 16 — Prose distinguishes constructor vs. static `initAvo` return types:** The prose accompanying the two Swift pattern examples explicitly states that the constructor `initAvo` returns an `Avo` instance (which is stored and injected as a dependency) while the static `initAvo` returns void (storing state globally). An implementation that shows two nearly-identical code blocks with no explanatory text distinguishing return type and state model is a failing outcome.
+
+## Open Questions Resolved
+
+- **Which pattern is the default for new workspaces?**
+  Constructor/object-based is the default for all new workspaces. Lead with it.
+
+- **Should we create new pages or update existing ones?**
+  Update existing pages in-place only. No new pages.
+
+- **Should the static pattern be completely removed?**
+  No. It must remain documented in a collapsible section since existing workspaces still use it.
+
+- **Should Swift examples use actor/async?**
+  The constructor example must use `await` because all constructor-variant generated files produce an async `initAvo`. Actor/Swift 6 strict concurrency specifics remain excluded. The static example must not use `await`.
+
+- **What collapsible component to use?**
+  Use native HTML `<details>`/`<summary>` elements, consistent with the pattern in `start-using-inspector-with-avo-codegen.mdx` and `bulk-editing.mdx`. The `<details>` element must not have the `open` attribute.
+
+- **What is the accurate Swift constructor call site?**
+  `let avo = await Avo.initAvo(env: .dev, ...)` (async factory method returning an `Avo` instance); event tracking via `avo.testEmptyEvent()`.
+  Source: `constructor_analytics/Buttons/Managers/AppDelegate.swift` — uses `Task { avo = await Avo.initAvo(...) }`
+
+- **Is there a non-async Swift constructor call site in the test suite?**
+  No. All constructor-analytics Swift test files call `await Avo.initAvo(...)` wrapped in a `Task`. There is no synchronous constructor call site. The original "no async" constraint is revised to allow `await` in the constructor example while still excluding actor/Swift 6 specifics.
+
+- **What is the accurate Kotlin constructor class name?**
+  The generated class is named `[WorkspacePrefix]AvoImpl`. The test workspace prefix is "Constructor", producing `ConstructorAvoImpl`. For a generic new workspace (no prefix), the class is `AvoImpl`. Documentation must use `AvoImpl` as the generic name with a note about workspace prefix variation.
+  Source: `constructoranalytics/ConstructorActivity.kt` — uses `ConstructorAvoImpl`; `kotlin.mdx` already uses `AvoImpl` as the generic form.
+
+- **What is the accurate Kotlin constructor call site?**
+  `val avo = AvoImpl(application, context, AvoEnv.DEV, ...)` then `avo.testEmptyEvent()`.
+  Source: `constructoranalytics/ConstructorActivity.kt`, with `AvoImpl` substituted for the workspace-specific `ConstructorAvoImpl`.
+
+- **What is the accurate Kotlin static call site?**
+  `StaticAvo.initAvoWithInspector(inspector, application, context, AvoEnv.DEV, ...)` then `StaticAvo.eventName(...)`.
+  Source: `staticanalytics/StaticActivity.kt`.
+
+- **What is the accurate Swift static call site?**
+  `Avo.initAvo(env: .dev, ...)` (synchronous, void return, sets global state) then `Avo.testEmptyEvent()`.
+  Source: `static_analytics/Buttons/Managers/AppDelegate.swift`.
+
+- **What component should the DI callout use?**
+  `<Callout type="info">` on both reference pages. The `Callout` import must be added to `swift.mdx` and `kotlin.mdx`.
+
+## Dependencies
+
+- No external service dependencies.
+- The three MDX files to edit must remain syntactically valid for the Nextra/Next.js docs build. Run `npm run build` in the docs repo before submitting to confirm no new compilation errors.
+- Add `import { Callout } from 'nextra/components'` to `swift.mdx` and `kotlin.mdx`.
+- Platform test files used as reference sources (read-only, no changes required):
+  - `/Users/alexverein/code/avo/monorepo2/platform_tests/ios/swift/Buttons/constructor_analytics/Buttons/Managers/AppDelegate.swift` (Swift constructor — async)
+  - `/Users/alexverein/code/avo/monorepo2/platform_tests/ios/swift/Buttons/constructor_analytics/ButtonsTests/Helpers/AvoHelper.swift`
+  - `/Users/alexverein/code/avo/monorepo2/platform_tests/ios/swift/Buttons/swift6_actor/Buttons/ViewController.swift`
+  - `/Users/alexverein/code/avo/monorepo2/platform_tests/ios/swift/Buttons/static_analytics/Buttons/Managers/AppDelegate.swift` (Swift static — synchronous)
+  - `/Users/alexverein/code/avo/monorepo2/platform_tests/ios/swift/Buttons/static_analytics/Buttons/Controllers/ViewController.swift` (Swift static usage — `Avo.testEmptyEvent()` call shape; also used as reference for Swift constructor usage example in AC 15, substituting instance form `avo.testEmptyEvent()`)
+  - `/Users/alexverein/code/avo/monorepo2/platform_tests/android/kotlin/AndroidKotlin/constructoranalytics/src/main/java/app/avo/constructoranalytics/ConstructorActivity.kt`
+  - `/Users/alexverein/code/avo/monorepo2/platform_tests/android/kotlin/AndroidKotlin/staticanalytics/src/main/java/app/avo/staticanalytics/StaticActivity.kt`
+
+## Revision History
+
+### Rev 1 — 2026-04-02 (Wednesday)
+Initial draft.
+
+### Rev 2 — 2026-04-02 (Wednesday)
+Addressed Morticia Rev 1 feedback (9 Critical/Important issues):
+- Resolved Swift async contradiction — all constructor test files are async; revised constraint to permit `await` in constructor examples, exclude actor/Swift6 specifics only
+- Reconciled Kotlin class name — `ConstructorAvoImpl` in test is workspace-prefixed; `AvoImpl` is the correct generic form
+- Added Current State Analysis and pedagogical design note
+- Rewrote all ACs to be binary pass/fail with expected outcomes
+- Added AC 11 (KMP caveat), AC 12 (Callout imports), AC 13 (build passes)
+- Committed to specific component per location (Callout vs. details table)
+- Noted `kotlin.mdx` pre-existing syntax error and `######` heading as known out-of-scope debt
+
+### Rev 3 — 2026-04-02 (Wednesday)
+Addressed Morticia Rev 2 feedback (3 Important, 5 Minor issues):
+- Added `public init` vs `Avo.initAvo` discrepancy note; added AC 14 requiring Swift Reference Constructor signature correction
+- Rewrote AC 4 to name `StaticAvo.initAvoWithInspector(...)` explicitly as the required Kotlin static init method
+- Added AC 15 requiring Swift constructor usage example (`avo.someEvent()`)
+- Added AC 16 for prose distinguishing return types
+- Expanded AC 10 with Kotlin constructor minimum alignment and `avo.track(...)` contamination warning
+- Added clause to AC 1/AC 3 that static pattern must not appear in Step 2


### PR DESCRIPTION
## Summary
- Adds feature spec for documenting the constructor/object-based and static (legacy) API patterns in Swift and Kotlin codegen docs (AVO-2599)
- Spec covers changes to `swift.mdx`, `kotlin.mdx`, and `avo-codegen-tech-deep-dive.mdx`
- Scored 92/100 by automated Morticia QA review after 3 revision cycles

## Context
Developers evaluating Avo for DI-heavy codebases (e.g., swift-dependencies, Hilt) couldn't discover the constructor/object-based pattern from the docs — only the static/function-per-event pattern was documented. This spec defines the changes needed to fix that gap.

## Files
- `planning/swift-codegen-docs-api-shapes/spec.md` — feature spec (16 acceptance criteria)
- `planning/swift-codegen-docs-api-shapes/interview-brief.md` — interview context
- `planning/swift-codegen-docs-api-shapes/spec-review.md` — Morticia QA review

## Next steps
Run `/pugsley swift-codegen-docs-api-shapes` to generate the implementation PRD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added planning and specification documents for Swift and Kotlin SDK codegen, including interview briefs with acceptance criteria, architectural spec reviews with identified issues, and detailed API shape specifications with documentation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->