### PR TITLE
Update Avo MCP docs to cover write tools (beta) and current tool inventory

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -82,6 +82,8 @@
         "Agentic",
         "bnpl",
         "ECIES",
-        "ECDH"
+        "ECDH",
+        "Streamable",
+        "PKCE"
     ]
 }

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -1,26 +1,58 @@
 import { Callout } from 'nextra/components'
 
-# Avo MCP (Beta)
+# Avo MCP
 
-The Avo MCP (Model Context Protocol) server exposes your Avo tracking plan to AI coding assistants. With it, tools like Claude, ChatGPT, Cursor, Codex, and other MCP-compatible clients can read your tracking plan, explore branches, and generate correct analytics instrumentation — without you having to copy-paste event specs into the chat.
+The Avo MCP (Model Context Protocol) server exposes your Avo tracking plan to AI coding assistants. Tools like Claude, ChatGPT, Cursor, Codex, Claude Code, and other MCP-compatible clients can **read** your tracking plan, **explore branches**, and **write changes on a branch** — without you copy-pasting specs into the chat.
+
+- **Transport:** Streamable HTTP at `https://mcp.avo.app/mcp`
+- **Authentication:** OAuth 2.0 + PKCE, scoped to your Avo identity
+- **Writes:** always happen on a branch (never directly on main). Merging to main stays a human step in the Avo app.
 
 <Callout type="warning" emoji="🚧">
-  The Avo MCP is currently in **beta** and is read-only. We are actively working on write functionality. [Let us know what write capabilities you'd like to see](mailto:support@avo.app) — your feedback shapes what we build next.
+  **Write access is in closed beta.** The `read` tools are generally available; the `write` tools (`workflow` and `save_items`) are enabled per-workspace. [Email us at support@avo.app](mailto:support@avo.app) if you'd like your workspace added to the beta.
 </Callout>
 
-What you can do with the Avo MCP:
+<Callout type="warning" emoji="🔒">
+  Writes require the `write` scope and always happen on a branch. The MCP server will never merge a branch into main — that remains a human step in the [Avo web app](https://www.avo.app).
+</Callout>
 
-- Browse tracking plan branches and see what changed
-- Get implementation guides and code diffs for a specific source
-- Look up details for any tracking plan item — events, properties, metrics, and more
-- Search for events and properties by meaning
+## What you can do
+
+### Read (scope: `read`)
+
+- Browse branches and see who created, reviewed, or collaborated on them
+- Get implementation guides and code diffs for a specific source on a branch
+- Look up details for any tracking plan item — events, properties, metrics, categories, property bundles, sources, destinations, group types, event variants
+- Search the plan semantically by meaning
 - Discover available sources in your workspace
+
+### Write (scope: `write`)
+
+- Create a new branch from main
+- Create, update, and (for some entities) remove events, properties, and event variants on a branch
+- Cross-reference newly created items inside a single batch using temporary IDs
+
+## Capability matrix
+
+| Capability | Tool | Scope |
+|---|---|---|
+| Health check | [`health_check`](/reference/avo-mcp/tools#health_check) | `read` |
+| List workspaces you can access | [`list_workspaces`](/reference/avo-mcp/tools#list_workspaces) | `read` |
+| List branches in a workspace | [`list_branches`](/reference/avo-mcp/tools#list_branches) | `read` |
+| Branch details (reviewers, status, impacted sources) | [`get_branch_details`](/reference/avo-mcp/tools#get_branch_details) | `read` |
+| What changed on a branch (implementation guide) | [`get_branch_implementation_guide`](/reference/avo-mcp/tools#get_branch_implementation_guide) | `read` |
+| Per-event code diffs for a branch + source | [`get_branch_code_snippets`](/reference/avo-mcp/tools#get_branch_code_snippets) | `read` |
+| List sources in a workspace | [`get_sources`](/reference/avo-mcp/tools#get_sources) | `read` |
+| Look up any item by ID or exact name | [`get`](/reference/avo-mcp/tools#get) | `read` |
+| Semantic search across the plan | [`search`](/reference/avo-mcp/tools#search) | `read` |
+| Create a branch | [`workflow`](/reference/avo-mcp/tools#workflow) | `write` |
+| Create / update / remove events, properties, event variants on a branch | [`save_items`](/reference/avo-mcp/tools#save_items) | `write` |
+
+See the [Tools reference](/reference/avo-mcp/tools) for full parameters, return shapes, and examples per tool.
 
 ## Setup
 
 ### Claude Code (CLI)
-
-Run this command to add the Avo MCP server:
 
 ```bash
 claude mcp add avo --transport http https://mcp.avo.app/mcp
@@ -28,9 +60,9 @@ claude mcp add avo --transport http https://mcp.avo.app/mcp
 
 ### Claude Desktop app
 
-1. Open Claude Desktop and go to **Customize** → **Connectors**
+1. Open Claude Desktop → **Customize** → **Connectors**
 2. Click **Add custom connector**
-3. Set the name to `Avo` and the remote MCP server URL to `https://mcp.avo.app/mcp`
+3. Name: `Avo`, Remote MCP server URL: `https://mcp.avo.app/mcp`
 
 <Callout type="info" emoji="🔒">
   Adding connectors in Claude Desktop requires admin permissions in your organization.
@@ -38,7 +70,7 @@ claude mcp add avo --transport http https://mcp.avo.app/mcp
 
 ### Cursor
 
-Add the following to your `mcp.json` file (or `~/.cursor/mcp.json` for global configuration):
+Add the following to your `mcp.json` (or `~/.cursor/mcp.json` for global config):
 
 ```json
 {
@@ -52,8 +84,6 @@ Add the following to your `mcp.json` file (or `~/.cursor/mcp.json` for global co
 
 ### Other MCP clients
 
-Add the Avo MCP server to your client's configuration file (commonly `mcp.json`):
-
 ```json
 {
   "mcpServers": {
@@ -64,40 +94,54 @@ Add the Avo MCP server to your client's configuration file (commonly `mcp.json`)
 }
 ```
 
-Your client must support both HTTP transport and the browser-based OAuth authorization flow described in the [Authentication](#authentication) section below — the first tool invocation will open a browser window to complete authorization, after which the token is cached. Clients that cannot complete the OAuth flow will not work with the Avo MCP server.
+Your client must support HTTP transport and the browser-based OAuth authorization flow. The first tool invocation opens a browser, you sign in with your Avo credentials, the client receives a token, and the token is cached for subsequent calls. Clients that cannot complete the OAuth flow will not work with the Avo MCP.
 
 ## Authentication
 
-The MCP server uses OAuth to authenticate you with Avo. The first time you invoke a tool, your MCP client will prompt you to complete an authorization flow in your browser. Once authenticated, the token is cached for subsequent requests.
+The MCP server uses OAuth 2.0 with PKCE.
+
+- **Protected resource metadata:** served at [`https://mcp.avo.app/.well-known/oauth-protected-resource`](https://mcp.avo.app/.well-known/oauth-protected-resource) per [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728). The authorization server is `https://api.avo.app` — clients discover its endpoints via `https://api.avo.app/.well-known/oauth-authorization-server`.
+- **Dynamic client registration:** `POST https://api.avo.app/oauth/register` per [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591). Most MCP clients register themselves automatically on first connect.
+- **Scopes:** `read` and `write`. Clients request `read` by default. When you invoke a write tool, your client will step up and request the `write` scope (a second browser prompt). Tokens carry the user identity; workspace access is verified at call time against your Avo workspace membership.
+- **Token signing:** RS256 keys backed by Google Cloud KMS (HSM) in production.
+
+If a tool that requires `write` is called with a token that only has `read`, the server returns an error prompting the client to re-authorize with `write`.
 
 ## Getting started
 
-Most tools are workspace-scoped (`health_check` and `list_workspaces` are the exceptions). The typical first-use sequence is:
+Most tools are workspace-scoped (`health_check` and `list_workspaces` are the exceptions). The typical first-use sequence:
 
 **1. Discover your workspaces**
 
-Call `list_workspaces` to see which Avo workspaces you have access to and find your workspace ID.
+Call `list_workspaces` to find your `workspaceId`.
 
 **2. Use any tool**
 
-Pass your `workspaceId` to any tool, or omit it if your MCP client has it configured. You can browse branches, look up sources, search for events, and get implementation guides directly in your AI session.
+Pass `workspaceId` to every workspace-scoped tool. (Stdio clients can also set the `WORKSPACE_ID` environment variable so it's picked up automatically.)
 
-## Common workflows
+## Recommended agent flows
 
-### Implementing a tracking plan branch
+### Explore the plan
 
-1. `list_branches` — find the branch you're working on
-2. `get_sources` — discover available sources (e.g. "iOS App", "Web App")
-3. `get_branch_implementation_guide` with a `branchId` and a `sourceId` — get a summary of what changed and what to implement on a specific branch
-4. `get_branch_code_snippets` with a `branchId` and a `sourceId` — get implementation snippets for each changed event (exact diffs for Codegen sources, pseudocode for manual sources) on a specific branch
+`list_workspaces` → `search` or `get` to inspect items by meaning or by ID/name.
 
-### Looking up a tracking plan item
+### Find work on a branch
 
-Use `get` with an item ID to fetch full details for any tracking plan item — events, properties, metrics, categories, property bundles, sources, destinations, group types, or event variants. You can find item IDs from `search` results, branch details, or implementation guides.
+`list_branches` → `get_branch_details` → `get_branch_implementation_guide` → `get_branch_code_snippets` (with a `sourceId` from `get_sources`).
+
+### Add events for a new feature
+
+1. `workflow` with `action: "create_branch"` and a `branchName` → returns `branchId`.
+2. `save_items` on that `branchId` with a batch of `event` / `property` / `event_variant` items. Use `tempId` for forward references so a newly created property can be attached to a newly created event in a single call.
+3. Tell the user the branch is ready — the MCP does not merge. Open the branch in the [Avo web app](https://www.avo.app) (or ask a reviewer) to review and merge it to main.
+
+### Fix a property on an existing branch
+
+`list_branches` → `get_branch_details` to get `branchId` → `save_items` with `op: "update"` targeting an `eventId` or `propertyId`.
 
 ### Searching for an event
 
-Use `search` to find events by meaning, not just exact name. The tool uses vector similarity search, so queries like "user signed up" will match events named `Account Created` or `Registration Completed`.
+Use `search` to find events by meaning, not just exact name. A query like `"user signed up"` will match events named `Account Created` or `Registration Completed`.
 
 <Callout type="info" emoji="🔒">
   Semantic search requires Avo Intelligence Smart Search to be enabled in your workspace. Workspace admins can enable it in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). If you don't have admin access, ask a workspace admin to enable it.
@@ -105,4 +149,4 @@ Use `search` to find events by meaning, not just exact name. The tool uses vecto
 
 ## Tools
 
-See the [Tools reference](/reference/avo-mcp/tools) for the full list of available tools and their parameters.
+See the [Tools reference](/reference/avo-mcp/tools) for the full list of tools and their parameters.

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -2,33 +2,64 @@ import { Callout } from 'nextra/components'
 
 # Avo MCP tools reference
 
-All tools (except `health_check` and `list_workspaces`) operate on a workspace. Most tools accept an optional `workspaceId` parameter and support branch resolution by either ID or name.
+Every tool except `health_check` and `list_workspaces` operates on a workspace. Pass `workspaceId` as a parameter; stdio clients can also set the `WORKSPACE_ID` environment variable.
+
+<Callout type="info" emoji="🔒">
+  Tools are grouped below by capability. Each tool lists the OAuth scope required. Write tools (`workflow`, `save_items`) require the `write` scope, which is requested as a separate consent step on first use.
+</Callout>
+
+**Discovery & navigation**
+- [`health_check`](#health_check) — verify the server is up
+- [`list_workspaces`](#list_workspaces) — find your workspace IDs
+- [`list_branches`](#list_branches) — browse branches
+- [`get_sources`](#get_sources) — find source IDs for a workspace
+
+**Reading the plan**
+- [`get`](#get) — get item details by ID or exact name
+- [`search`](#search) — semantic similarity search
+
+**Reading a specific branch**
+- [`get_branch_details`](#get_branch_details) — full branch details (resolved emails, impacted sources, status)
+- [`get_branch_implementation_guide`](#get_branch_implementation_guide) — what changed on a branch
+- [`get_branch_code_snippets`](#get_branch_code_snippets) — per-event code diffs for a branch + source
+
+**Writing (beta)**
+- [`workflow`](#workflow) — progress the plan forward (e.g. create a branch)
+- [`save_items`](#save_items) — create / update / remove events, properties, event variants on a branch
 
 ---
 
 ## `health_check`
 
+**Scope:** `read`
+
 Verify the MCP server is running and responsive.
 
 **Parameters:** None
 
-**Returns:** Simple "OK" health status.
+**Returns:** A simple `OK` status.
 
 ---
 
 ## `list_workspaces`
 
-List the Avo workspaces you have access to.
+**Scope:** `read`
+
+List the Avo workspaces the authenticated user has access to.
 
 **Parameters:** None
 
-**Returns:** Each workspace's name, ID, and your role in it.
+**Returns:** One row per workspace: name, workspace ID, and the user's role.
+
+Call this first to discover workspace IDs before invoking any workspace-scoped tool.
 
 ---
 
 ## `list_branches`
 
-Browse branches in the workspace.
+**Scope:** `read`
+
+Browse branches in a workspace with filtering and pagination. Results are paginated newest-first.
 
 **Parameters:**
 
@@ -36,49 +67,62 @@ Browse branches in the workspace.
 |---|---|---|
 | `workspaceId` | No | Workspace ID |
 | `branchStatuses` | No | Filter by status. Valid values: `Draft`, `ReadyForReview`, `ChangesRequested`, `Approved`, `Merged`, `Closed`, `Open`. Defaults to open/active branches only. |
-| `pageSize` | No | Number of results per page (1–50, default 25) |
+| `pageSize` | No | Results per page (1–50, default 25) |
 | `pageToken` | No | Pagination token from a previous response |
-| `branchName` | No | Substring match on branch name |
+| `branchName` | No | Substring match on branch name (case-insensitive) |
 | `creatorEmail` | No | Filter by creator email |
 | `creatorUserId` | No | Filter by creator user ID |
 | `reviewerEmail` | No | Filter by reviewer email |
 | `reviewerUserId` | No | Filter by reviewer user ID |
 | `collaboratorEmail` | No | Filter by collaborator email |
 | `collaboratorUserId` | No | Filter by collaborator user ID |
-| `createdAfter` | No | Filter to branches created after this date |
-| `createdBefore` | No | Filter to branches created before this date |
-| `impactedSourceId` | No | Filter to branches that affect a specific source |
+| `createdAfter` | No | ISO 8601 date — only branches created after |
+| `createdBefore` | No | ISO 8601 date — only branches created before |
+| `impactedSourceId` | No | Filter to branches affecting a specific source |
 
-**Returns:** Compact summary per branch: name, status, ID, and creator email. Results are paginated, newest-first.
+**Returns:** Compact per-branch summary — name, status, ID, creator email — plus a `nextPageToken` when more results are available. Call `get_branch_details` for full resolved data.
 
-By default, `Merged` and `Closed` branches are excluded to reduce noise. Pass `branchStatuses: ["Merged"]` (or any other status) to include them.
+<Callout type="info" emoji="💡">
+  To find "my branches," pass your own email as `creatorEmail` or `reviewerEmail`. The tool does not auto-inject your identity into the filter.
+</Callout>
+
+By default `Merged` and `Closed` branches are excluded. Pass `branchStatuses: ["Merged"]` (or any other value) to include them.
+
+**Common errors:** workspace access denied, invalid `pageSize`, invalid date format.
 
 ---
 
 ## `get_branch_details`
 
-Get full details for a specific branch.
+**Scope:** `read`
+
+Full details for a specific branch.
 
 **Parameters:**
 
 | Parameter | Required | Description |
 |---|---|---|
 | `branchId` | One of `branchId` or `branchName` | Branch ID (takes precedence over name) |
-| `branchName` | One of `branchId` or `branchName` | Branch name (case-insensitive; matches open branches) |
+| `branchName` | One of `branchId` or `branchName` | Branch name — best-match, prioritizes open branches |
 | `workspaceId` | No | Workspace ID |
 
-**Returns:** Full branch details including:
+**Returns:**
 - Resolved emails for the creator, all reviewers, and all collaborators
-- The complete list of impacted source IDs
+- Branch status
+- Complete list of impacted source IDs
 - Branch description
 
 Use this after `list_branches` to drill into a specific branch.
+
+**Common errors:** branch not found, ambiguous branch name, workspace access denied.
 
 ---
 
 ## `get_branch_implementation_guide`
 
-Get a high-level implementation guide for a branch's tracking plan changes.
+**Scope:** `read`
+
+High-level implementation guide for a branch — everything an implementer needs to understand what changed.
 
 **Parameters:**
 
@@ -91,47 +135,51 @@ Get a high-level implementation guide for a branch's tracking plan changes.
 
 **Returns:**
 
-- **Summary**: total count of new, modified, and deleted events
-- **New events**: name, description, list of properties, and whether the source uses Avo Codegen or manual implementation
-- **Modified events**: what changed (name, description, or properties) with before/after values
-- **Deleted events**: name, description, and properties
-- **Implementation steps**: instructions based on your source type (Codegen: check `avo.json`, run `avo pull`, import, implement, validate; Manual: what to add, change, or remove)
+- **Summary:** counts of new, modified, and deleted events
+- **New events:** name, description, property list, and whether the source uses Avo Codegen or manual implementation
+- **Modified events:** what changed (name, description, properties) with before/after values
+- **Deleted events:** name, description, properties
+- **Implementation steps:** instructions tailored to the source type (Codegen: check `avo.json`, run `avo pull`, import, implement, validate; Manual: what to add, change, or remove)
 
-When `sourceId` is provided, the guide filters to changes affecting only that source and tailors the implementation steps accordingly.
+When `sourceId` is provided, the guide filters to changes affecting only that source.
 
-**When to use this vs `get_branch_code_snippets`:** Use this tool to understand the scope of changes and get structured guidance. Use `get_branch_code_snippets` when you need the actual code diffs to write implementation code.
+**When to use this vs `get_branch_code_snippets`:** Use this tool to understand the *scope* of changes. Use `get_branch_code_snippets` when you need the actual code diffs to write implementation code.
 
 ---
 
 ## `get_branch_code_snippets`
 
-Get implementation snippets for all changed events on a branch, for a specific source.
+**Scope:** `read`
+
+Per-event code snippets — unified diffs — for all changed events on a branch, for a specific source.
 
 **Parameters:**
 
 | Parameter | Required | Description |
 |---|---|---|
-| `sourceId` | Yes | Source ID to get code snippets for. Use `get_sources` to find IDs. |
+| `sourceId` | Yes | Source ID. Use `get_sources` to find source IDs. |
 | `branchId` | One of `branchId` or `branchName` | Branch ID |
 | `branchName` | One of `branchId` or `branchName` | Branch name |
 | `workspaceId` | No | Workspace ID |
 
 **Returns:** Per-event implementation snippets, including:
 
-- **Event status**: New, Added (to source), Updated, Removed (from source), or Deleted
-- **Label**: `[Codegen]` or `[Pseudocode]` per event, indicating whether generated code (`avo pull`) or manual implementation applies
-- **Diff**: exact unified diff between main and current branch for `[Codegen]` events; illustrative before/after guidance for `[Pseudocode]` events (not a guaranteed exact patch)
-- **Contextual guidance** per event (e.g., run `avo pull` for Codegen events, implement manually for pseudocode events, remove calls for deleted events)
+- **Event status:** New, Added (to source), Updated, Removed (from source), or Deleted
+- **Label:** `[Codegen]` or `[Pseudocode]` per event
+- **Diff:** exact unified diff between main and the branch for `[Codegen]` events; illustrative before/after for `[Pseudocode]` events
+- **Contextual guidance** per event (e.g., run `avo pull` for Codegen, implement manually for pseudocode, remove calls for deleted events)
 
 <Callout type="info" emoji="💡">
-  **Codegen vs pseudocode:** Avo sources can use Avo Codegen (type-safe generated code pulled via `avo pull`) or manual implementation (where Avo provides pseudocode as a reference). `[Codegen]` events include exact unified diffs you can apply directly; `[Pseudocode]` events provide illustrative guidance to help you write the implementation manually. The label on each event tells you which applies.
+  **Codegen vs pseudocode.** Avo sources can use Avo Codegen (type-safe generated code pulled via `avo pull`) or manual implementation (Avo provides pseudocode as reference). `[Codegen]` events include exact unified diffs; `[Pseudocode]` events provide illustrative guidance to help you write the implementation manually.
 </Callout>
 
 ---
 
 ## `get_sources`
 
-List all sources in the workspace.
+**Scope:** `read`
+
+List sources in a workspace. Sources represent the different places in your codebase where tracking fires — for example, "iOS App", "Web App", or "Backend Service".
 
 **Parameters:**
 
@@ -141,30 +189,43 @@ List all sources in the workspace.
 | `branchId` | No | Branch ID. Defaults to the main branch. |
 | `branchName` | No | Branch name. Defaults to the main branch. |
 
-**Returns:** A table of sources with: source name, programming language, platform, filename hint, and source ID. Sources with no language or platform configured are flagged.
+**Returns:** A table of sources — name, programming language, platform, filename hint, and source ID. Sources with no language or platform configured are flagged.
 
-Sources represent the different places in your codebase where tracking fires — for example, "iOS App", "Web App", or "Backend Service". Call this tool to find the `sourceId` before using `get_branch_implementation_guide` or `get_branch_code_snippets`.
+Call this to find a `sourceId` before using `get_branch_implementation_guide` or `get_branch_code_snippets`.
 
 ---
 
 ## `get`
 
-Get details for any tracking plan item by ID.
+**Scope:** `read`
+
+Universal item-details tool. Look up a single tracking plan item by ID or exact name. Defaults to the main branch.
 
 **Parameters:**
 
 | Parameter | Required | Description |
 |---|---|---|
-| `itemId` | Yes | The ID of the item to look up |
+| `type` | Yes | Item type. One of: `event`, `property`, `metric`, `category`, `propertyBundle`, `source`, `destination`, `groupType`, `eventVariant`. |
+| `id` | One of `id` or `name` | The item's unique ID. |
+| `name` | One of `id` or `name` | Exact name match. May return multiple matches for ambiguous names (especially properties) — use `search` for fuzzy lookup. |
+| `variantId` | For `eventVariant` | The variant ID. Combined with `id` (the base event ID). |
+| `branchId` | No | Branch to look up on. Defaults to main. `branchId` takes precedence over `branchName`. |
+| `branchName` | No | Alternative to `branchId`. |
+| `includePropertyDetails` | No | Events only. When `true`, includes full property definitions (type, constraints, allowed values). Defaults to `false`, which returns only property ID + name references. |
+| `includeArchived` | No | When `true` (default), includes archived items in results. When `false`, only active items. |
 | `workspaceId` | No | Workspace ID |
 
-**Returns:** Full details for the item. Supports events, properties, metrics, categories, property bundles, sources, destinations, group types, and event variants.
+**Returns:** Full details for the item, shaped per item type.
+
+**Common errors:** item not found, ambiguous name (returns multiple matches — narrow by ID), workspace access denied.
 
 ---
 
 ## `search`
 
-Search across the tracking plan using semantic similarity.
+**Scope:** `read`
+
+Semantic similarity search across events, properties, metrics, categories, and property bundles. Uses vector similarity, not keyword matching — a query like `"user signed up"` will match `Account Created` or `Registration Completed` by meaning.
 
 **Parameters:**
 
@@ -173,14 +234,211 @@ Search across the tracking plan using semantic similarity.
 | `query` | Yes | Natural language search query |
 | `workspaceId` | No | Workspace ID |
 | `itemType` | No | Filter by type: `event`, `property`, `metric`, `category`, or `propertyBundle` |
-| `maxResults` | No | Number of results to return (1–20, default 10) |
+| `maxResults` | No | Number of results (1–20, default 10) |
 
-**Returns:** Ranked results with: rank, name, type, item ID, relevance percentage, and a truncated description (80 characters).
+**Returns:** Ranked results with rank, name, type, item ID, relevance percentage, and a truncated description (80 characters).
 
-The search uses vector similarity, not keyword matching. A query like "user signed up" will match events named `Account Created` or `Registration Completed` based on meaning.
-
-Search is performed against the **main branch** only. There may be a short lag for very recently created or updated items.
+Search is performed against the **main branch** only. There is a brief indexing lag for very recently created or updated items.
 
 <Callout type="info" emoji="🔒">
   Semantic search requires Avo Intelligence Smart Search to be enabled in your workspace. Workspace admins can enable it in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). If you don't have admin access, ask a workspace admin to enable it.
 </Callout>
+
+---
+
+## `workflow`
+
+**Scope:** `write`
+
+<Callout type="warning" emoji="🚧">
+  Write access is in closed beta. [Email support@avo.app](mailto:support@avo.app) to have your workspace enabled.
+</Callout>
+
+Progress the tracking plan forward. Currently supports one action: creating a branch.
+
+**Parameters:**
+
+| Parameter | Required | Description |
+|---|---|---|
+| `action` | Yes | The workflow action. Supported: `create_branch`. |
+| `branchName` | Yes | Name for the new branch. |
+| `workspaceId` | No | Workspace ID |
+
+**Returns:** The new branch's `branchId`, `branchName`, and a `branchUrl` that opens it in the Avo web app.
+
+<Callout type="info" emoji="💡">
+  A branch is a draft workspace for tracking-plan changes, analogous to a git branch. All write operations via the MCP happen on a branch — `save_items` requires a `branchId` that exists. The MCP never merges to main; open the branch in the Avo app to review and merge.
+</Callout>
+
+**Common errors:** missing `write` scope (re-authorize with write), workspace access denied, unsupported action value.
+
+---
+
+## `save_items`
+
+**Scope:** `write`
+
+<Callout type="warning" emoji="🚧">
+  Write access is in closed beta. [Email support@avo.app](mailto:support@avo.app) to have your workspace enabled.
+</Callout>
+
+Batch create, update, and remove events, properties, and event variants on a branch. A single call can mix item types and operations, and can cross-reference new items via temporary IDs.
+
+**Top-level parameters:**
+
+| Parameter | Required | Description |
+|---|---|---|
+| `branchId` | Yes | The branch to write to. Get it from `workflow`/`create_branch` or `list_branches`. |
+| `items` | Yes | Array of items to apply. Each item is typed by its `type` field (`event`, `property`, or `event_variant`) and has an `op` (`create`, `update`, or `remove`, default `create`). |
+| `workspaceId` | No | Workspace ID |
+
+The request is capped at **100 items** per call.
+
+### Item shape
+
+Every item shares these fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `op` | `"create"` \| `"update"` \| `"remove"` | Defaults to `"create"`. `remove` is not supported for `event_variant`. |
+| `type` | `"event"` \| `"property"` \| `"event_variant"` | Required. |
+| `name` | string | Required on `create` for events and properties. Cosmetic (optional and ignored on writes) for `event_variant` items. |
+| `tempId` | string | **Create only.** Declares a temporary handle (e.g. `"prop1"`). Reference it elsewhere in the same call as `"$tmp:prop1"`. The server allocates a real ID and resolves all `$tmp:` references before writing. |
+| `eventId` | string | Required on `update` / `remove` of events. |
+| `propertyId` | string | Required on `update` / `remove` of properties. |
+| `baseEventId` | string | Required for `event_variant` items — the parent event's ID. Supports `$tmp:` refs. |
+| `variantId` | string | Required on `update` of `event_variant`. Caller-supplied on `create` of `event_variant`. |
+| `nameSuffix` | string | Required on `create` of `event_variant` — suffix appended to the parent event name (e.g. `buy_now` produces `click / buy_now`). |
+| `description` | string | Create-only. Event / property description. |
+
+**Create-event fields:**
+
+| Field | Notes |
+|---|---|
+| `properties` | Array of property IDs (or `$tmp:` refs) to attach. |
+| `sources` | Array of source IDs (or `$tmp:` refs) to include the event in. |
+
+**Create-property fields:**
+
+| Field | Notes |
+|---|---|
+| `propertyType` | `string`, `int`, `long`, `float`, `bool`, `object`, `any` (aliases like `integer`, `boolean`, `double` accepted). |
+| `sendAs` | `event`, `user`, or `system`. |
+
+**Create-event_variant fields:**
+
+| Field | Notes |
+|---|---|
+| `attachProperties` | Array of property IDs (or `$tmp:` refs) to attach to the variant. |
+| `overrides` | Component-level overrides. Each entry: `{ propertyId, pinned }` or `{ propertyId, allowed }`. `pinned` and `allowed` are mutually exclusive per override. |
+| `bundleOverrides` | Bundle IDs to attach to the variant as property bundles. |
+
+**Update-event fields:** _(require `eventId`)_
+
+| Field | Notes |
+|---|---|
+| `set.description` | New event description. |
+| `addProperties` / `removeProperties` | Property IDs (or `$tmp:` refs) to associate / disassociate. |
+| `addSources` / `removeSources` | Source IDs (or `$tmp:` refs) to include / exclude. |
+
+**Update-event_variant fields:** _(require `baseEventId` + `variantId`)_
+
+| Field | Notes |
+|---|---|
+| `set.nameSuffix` | New variant suffix. |
+| `set.description` | New variant description. |
+| `attachProperties` / `removeProperties` | Property IDs to attach / detach from this variant. |
+| `addComponentOverrides` | Override specs to add or replace. Same shape as create `overrides`. |
+| `removeComponentOverrides` | Property IDs whose overrides should be cleared. |
+
+**Update-property — allowed values:** _(require `propertyId`)_
+
+| Field | Notes |
+|---|---|
+| `addAllowedValues` | **Top-level on the item, not inside `set`.** String values to add to a string-typed property's allowed list. |
+| `removeAllowedValues` | **Top-level on the item, not inside `set`.** Values not in the current list are silently no-ops. |
+
+<Callout type="warning" emoji="🚧">
+  **Not yet implemented.** The following return a `NotYetImplemented` error from the server:
+
+  - `op: "remove"` on `event` items
+  - `op: "remove"` on `property` items
+  - `op: "update"` on `property` items with `set.description`, `set.propertyType`, or `set.sendAs`
+
+  Creating events/properties/event-variants, updating events and event variants, and updating a property's allowed values all work today.
+</Callout>
+
+### Temporary IDs (`tempId` / `$tmp:`)
+
+To reference a newly-created item from another item in the same call, declare a `tempId` on the `create` item and reference it elsewhere as `"$tmp:<name>"`:
+
+- `tempId` is **create-only** — setting it on an `update` or `remove` returns an error.
+- `tempId` names must be unique within a single `save_items` call.
+- `$tmp:` references are resolved in every reference position: `properties`, `sources`, `addProperties`, `removeProperties`, `addSources`, `removeSources`, `attachProperties`, `bundleOverrides`, and inside `overrides[].propertyId` / `addComponentOverrides[].propertyId`.
+- If a `$tmp:` ref names a tempId that wasn't declared on any item, the server returns a validation error.
+
+### Example: create a new event with a new property in one call
+
+```json
+{
+  "branchId": "br-abc123",
+  "items": [
+    {
+      "op": "create",
+      "type": "property",
+      "tempId": "checkout_method",
+      "name": "Checkout Method",
+      "propertyType": "string",
+      "sendAs": "event",
+      "description": "How the user completed checkout"
+    },
+    {
+      "op": "create",
+      "type": "event",
+      "name": "Checkout Completed",
+      "description": "Fired when the user finishes checkout",
+      "properties": ["$tmp:checkout_method"],
+      "sources": ["src-web", "src-ios"]
+    }
+  ]
+}
+```
+
+The server allocates a real ID for `checkout_method`, attaches the new property to the new `Checkout Completed` event, and includes the event in the `Web` and `iOS` sources — all atomically.
+
+### Example: add allowed values to an existing property
+
+```json
+{
+  "branchId": "br-abc123",
+  "items": [
+    {
+      "op": "update",
+      "type": "property",
+      "propertyId": "prop-abc123",
+      "addAllowedValues": ["Buy Now", "Subscribe"]
+    }
+  ]
+}
+```
+
+### Response
+
+Returns a structured result with:
+
+- `createdEntities`, `updatedEntities`, `removedEntities` — each entry has `name`, `entityId`, and `entityType` (`event`, `property`, or `event_variant`).
+- `errors` — per-item validation or audit errors, each with the item index, name, and a message.
+- `warnings` — non-fatal notices, same shape as errors.
+- `success` — overall boolean.
+
+**Common errors:**
+
+- Missing `write` scope — the client must re-authorize with `write`.
+- `branchId is required` / `items is required` — malformed request.
+- `tempId is only valid on create items` — don't set `tempId` on `update` or `remove`.
+- `Duplicate tempId "<name>"` — each `tempId` must be unique across items in the batch.
+- `Unknown $tmp: reference` — a `$tmp:` ref names a tempId that wasn't declared.
+- `<idField> is required for <op> <entity> items` — missing `eventId` / `propertyId` / `baseEventId` / `variantId`.
+- `too many items (got N, max 100)` — batch is over the 100-item cap.
+- `NotYetImplemented` — one of the unsupported operations above.
+- Per-item audit-pipeline validation failures (e.g. illegal name, duplicate property, etc.) — returned inside the `errors` array rather than failing the whole call.

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -306,8 +306,8 @@ Every item shares these fields:
 | `tempId` | string | **Create only.** Declares a temporary handle (e.g. `"prop1"`). Reference it elsewhere in the same call as `"$tmp:prop1"`. The server allocates a real ID and resolves all `$tmp:` references before writing. |
 | `eventId` | string | Required on `update` / `remove` of events. |
 | `propertyId` | string | Required on `update` / `remove` of properties. |
-| `baseEventId` | string | Required for `event_variant` items — the parent event's ID. Supports `$tmp:` refs. |
-| `variantId` | string | Required on `update` of `event_variant`. Caller-supplied on `create` of `event_variant`. |
+| `baseEventId` | string | Required for `event_variant` items — the parent event's ID. |
+| `variantId` | string | Required on `update` of `event_variant`. On `create`, provide either `variantId` directly or a `tempId` on the same item (the server resolves the `tempId` into `variantId`). |
 | `nameSuffix` | string | Required on `create` of `event_variant` — suffix appended to the parent event name (e.g. `buy_now` produces `click / buy_now`). |
 | `description` | string | Create-only. Event / property description. |
 
@@ -316,7 +316,7 @@ Every item shares these fields:
 | Field | Notes |
 |---|---|
 | `properties` | Array of property IDs (or `$tmp:` refs) to attach. |
-| `sources` | Array of source IDs (or `$tmp:` refs) to include the event in. |
+| `sources` | Array of source IDs to include the event in. Find source IDs with [`get_sources`](#get_sources). |
 
 **Create-property fields:**
 
@@ -339,7 +339,7 @@ Every item shares these fields:
 |---|---|
 | `set.description` | New event description. |
 | `addProperties` / `removeProperties` | Property IDs (or `$tmp:` refs) to associate / disassociate. |
-| `addSources` / `removeSources` | Source IDs (or `$tmp:` refs) to include / exclude. |
+| `addSources` / `removeSources` | Source IDs to include / exclude. |
 
 **Update-event_variant fields:** _(require `baseEventId` + `variantId`)_
 
@@ -374,7 +374,7 @@ To reference a newly-created item from another item in the same call, declare a 
 
 - `tempId` is **create-only** — setting it on an `update` or `remove` returns an error.
 - `tempId` names must be unique within a single `save_items` call.
-- `$tmp:` references are resolved in every reference position: `properties`, `sources`, `addProperties`, `removeProperties`, `addSources`, `removeSources`, `attachProperties`, `bundleOverrides`, and inside `overrides[].propertyId` / `addComponentOverrides[].propertyId`.
+- `$tmp:` references are resolved in these array fields: `properties`, `addProperties`, `removeProperties`, `attachProperties`, and inside `overrides[].propertyId` / `addComponentOverrides[].propertyId`. Source, destination, and bundle IDs cannot be `$tmp:` refs — they must be real IDs, since `save_items` does not create those entity types.
 - If a `$tmp:` ref names a tempId that wasn't declared on any item, the server returns a validation error.
 
 ### Example: create a new event with a new property in one call


### PR DESCRIPTION
## Summary

Brings the Avo MCP reference in line with the live server at `https://mcp.avo.app/mcp`, which now supports both read and write tools.

### Overview page (`overview.mdx`)

- Removes the "read-only beta" framing.
- Adds a capability matrix covering all 11 registered tools with OAuth scopes.
- Documents the OAuth 2.0 + PKCE flow, protected resource metadata (RFC 9728), dynamic client registration (RFC 7591), and RS256/KMS token signing.
- Adds recommended agent flows for "Add events for a new feature" and "Fix a property on an existing branch".
- Prominent closed-beta callout for the write tools with `support@avo.app` mailto for beta access.

### Tools reference (`tools.mdx`)

- Documents all 11 currently-registered tools: `health_check`, `list_workspaces`, `list_branches`, `get_branch_details`, `get_branch_implementation_guide`, `get_branch_code_snippets`, `get_sources`, `get`, `search`, `workflow`, `save_items`.
- Each tool now lists its required OAuth scope (`read` or `write`).
- `workflow` — documents the `create_branch` action. Returns `branchId`, `branchName`, `branchUrl`.
- `save_items` — full item-shape tables for `event`, `property`, and `event_variant`, plus the `tempId` / `\$tmp:` cross-referencing mechanism, two JSON examples (create-event-with-new-property in one call; add allowed values), response shape, and a "Not yet implemented" callout for `remove event`, `remove property`, and several update-property fields.
- "Writing (beta)" label on the write tools in the tool index.
- Closed-beta callouts on both write tool sections.

### What changed from the previous docs

- `set_workspace` / `save_workspace` is gone — every workspace-scoped tool takes `workspaceId` directly.
- Read surface expanded beyond the previous 4 tools: `get_sources`, `get_branch_details`, `get_branch_implementation_guide`, `get_branch_code_snippets`, `get`, and `search` are all documented.
- Write surface added: `save_items` and `workflow`, both gated on the `write` scope.

### Other

- `cspell.json`: added `Streamable` and `PKCE`.

## Test plan

- [ ] Verify overview page renders and the capability matrix links resolve to the tool anchors.
- [ ] Verify tool anchors (e.g. `#save_items`, `#workflow`) scroll to the right section.
- [ ] Confirm JSON code blocks render with syntax highlighting.
- [ ] Check closed-beta callouts render in Nextra style.
- [ ] Confirm `mailto:support@avo.app` links are clickable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Avo MCP reference—graduated from Beta status.
  * Expanded capabilities documentation with detailed read and write scopes.
  * Added comprehensive authentication guidance including OAuth 2.0 + PKCE.
  * Introduced recommended agent workflows for common tasks.
  * Documented beta write tools for creating and managing tracking plan items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->