### PR TITLE
Fix Inspector logging API name and document HTML snippet usage

### DIFF
--- a/pages/implementation/logs.mdx
+++ b/pages/implementation/logs.mdx
@@ -14,8 +14,35 @@ Avo Inspector prints logs prefixed with
 
 Logs are enabled by default in the development environment.
 
-You can enable or disable the logs with the following code:
+You can enable or disable the logs by calling `enableLogging` on your `AvoInspector` instance:
 
 ```swift
-AvoInspector.setLogging(shouldPrintLogs)
+// iOS (Swift)
+avoInspector.enableLogging(shouldPrintLogs)
+```
+
+```kotlin
+// Android (Kotlin) — static method on AvoInspector
+AvoInspector.enableLogging(shouldPrintLogs)
+```
+
+```js
+// Web / Node / React Native
+avoInspector.enableLogging(shouldPrintLogs)
+```
+
+### Web (HTML snippet) installations
+
+When the Avo Inspector is loaded via the HTML snippet, `window.inspector` starts as a method queue and is replaced by the real `AvoInspector` instance only after the CDN bundle finishes loading. `enableLogging` is not part of the queued methods, so it must be called once the SDK is initialized:
+
+```html
+<script>
+  (function waitForInspector() {
+    if (window.inspector && typeof window.inspector.enableLogging === 'function') {
+      window.inspector.enableLogging(false); // pass true to enable verbose logs
+    } else {
+      setTimeout(waitForInspector, 50);
+    }
+  })();
+</script>
 ```


### PR DESCRIPTION
## Summary
- The Inspector section of `pages/implementation/logs.mdx` referenced `AvoInspector.setLogging(shouldPringLogs)` — a method that does not exist on any of the Inspector SDKs (and had a typo).
- The actual API across all Inspector SDKs (web, node, RN, iOS, Android) is `enableLogging`. Updated the snippet to reflect that and added per-platform examples.
- Added a dedicated section for the HTML snippet installation. With the snippet, `window.inspector` is a method queue until the CDN bundle finishes loading, and `enableLogging` is not part of the queued methods, so it must be called after init. Included a small polling snippet users can copy.

## Test plan
- [ ] Render the docs site locally and verify the Logs page formats correctly
- [ ] Verify code blocks render with the right syntax highlighting (swift / kotlin / js / html)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated logging control documentation with refreshed API examples
  * Added platform-specific implementation guides for Swift, Android, and Web/Node/React Native
  * Included SDK integration workaround for proper initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->