### PR TITLE
Rename "Delete branch" to "Close branch" in branches docs

### DIFF
--- a/pages/data-design/branches/index.mdx
+++ b/pages/data-design/branches/index.mdx
@@ -46,11 +46,11 @@ A branch often corresponds to a single [journey](/data-design/avo-tracking-plan/
 
 Like in git, we recommend against creating big branches with a backlog of events and properties to be implemented. We'd rather recommend splitting them in to manageable chunks that will be implemented together in a single git branch.
 
-### Deleting a branch
+### Closing a branch
 
-Open the branch you want to delete, click the triple-dot in the top right corner and click "delete branch".
+Open the branch you want to close, click the triple-dot in the top right corner and click "Close branch". Closing a branch hides it from the active branches list without permanently removing it, so its history remains available.
 
-![Opening a branch](/images/delete-branch.png)
+![Closing a branch](/images/delete-branch.png)
 
 ### Renaming a branch
 


### PR DESCRIPTION
## Summary
- Updates the branches quickstart at `pages/data-design/branches/index.mdx` to reflect that the action is **Close branch**, not "Delete branch"
- Adds a short clarification that closing hides the branch from the active list while preserving its history (no hard delete)
- Renames the section heading and image alt text accordingly

## Test plan
- [ ] Visit /docs/data-design/branches and confirm the section reads "Closing a branch" with the updated copy
- [ ] Confirm the screenshot still renders (filename `delete-branch.png` is unchanged on disk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated branch management documentation with new guidance on closing branches. Closing a branch hides it from the active list without permanently removing it, while preserving all history—replacing the previous delete branch approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->