### PR TITLE
Update Avo MCP write tools status to general beta

### DIFF
--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -8,8 +8,8 @@ The Avo MCP (Model Context Protocol) server exposes your Avo tracking plan to AI
 - **Authentication:** OAuth 2.0 + PKCE, scoped to your Avo identity
 - **Writes:** always happen on a branch (never directly on main). Merging to main stays a human step in the Avo app.
 
-<Callout type="warning" emoji="🚧">
-  **Write access is in closed beta.** The `read` tools are generally available; the `write` tools (`workflow` and `save_items`) are enabled per-workspace. [Email us at support@avo.app](mailto:support@avo.app) if you'd like your workspace added to the beta.
+<Callout type="info" emoji="🚧">
+  **Write access is in general beta.** The `read` tools are generally available; the `write` tools (`workflow` and `save_items`) are now enabled for every workspace — no need to request access. We're still refining them, so [let us know at support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
 </Callout>
 
 <Callout type="warning" emoji="🔒">

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -9,7 +9,7 @@ The Avo MCP (Model Context Protocol) server exposes your Avo tracking plan to AI
 - **Writes:** always happen on a branch (never directly on main). Merging to main stays a human step in the Avo app.
 
 <Callout type="info" emoji="🚧">
-  **Write access is in general beta.** The `read` tools are generally available; the `write` tools (`workflow` and `save_items`) are now enabled for every workspace — no need to request access. We're still refining them, so [let us know at support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
+  **The Avo MCP is in general beta.** Both the `read` and `write` tools are enabled for every workspace — no need to request access. We're still refining them, so [let us know at support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
 </Callout>
 
 <Callout type="warning" emoji="🔒">

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -250,8 +250,8 @@ Search is performed against the **main branch** only. There is a brief indexing 
 
 **Scope:** `write`
 
-<Callout type="warning" emoji="🚧">
-  Write access is in closed beta. [Email support@avo.app](mailto:support@avo.app) to have your workspace enabled.
+<Callout type="info" emoji="🚧">
+  Write access is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
 </Callout>
 
 Progress the tracking plan forward. Currently supports one action: creating a branch.
@@ -278,8 +278,8 @@ Progress the tracking plan forward. Currently supports one action: creating a br
 
 **Scope:** `write`
 
-<Callout type="warning" emoji="🚧">
-  Write access is in closed beta. [Email support@avo.app](mailto:support@avo.app) to have your workspace enabled.
+<Callout type="info" emoji="🚧">
+  Write access is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
 </Callout>
 
 Batch create, update, and remove events, properties, and event variants on a branch. A single call can mix item types and operations, and can cross-reference new items via temporary IDs.


### PR DESCRIPTION
## What

The Avo MCP `workflow` and `save_items` write tools are no longer gated behind a per-workspace beta flag — they're now enabled for every workspace. This updates the docs accordingly.

## Changes

- `pages/reference/avo-mcp/overview.mdx` — top-level write-access callout now says "general beta", enabled for every workspace, no need to request access (kept a "still refining, let us know if anything's off" note). Switched callout type from `warning` to `info`.
- `pages/reference/avo-mcp/tools.mdx` — same update on the `workflow` and `save_items` tool callouts.

The existing `write` scope / branch-only callouts are left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Avo MCP transitioned to general beta status
  * Write access now enabled for all workspaces
  * Both read and write tools available to every workspace

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avohq/docs/pull/1700)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->