### PR TITLE
Cross-reference Avo MCP in tracking-plan docs

### DIFF
--- a/pages/data-design/avo-tracking-plan/events.mdx
+++ b/pages/data-design/avo-tracking-plan/events.mdx
@@ -34,9 +34,20 @@ Avo provides several ways to create events efficiently, depending on your workfl
 
 ### Fast event creation methods
 
-Fast creation methods are particularly useful when planning a new feature that requires multiple new events.
+Fast creation methods are particularly useful when planning a new feature that requires multiple new events. The fastest option is to drive an AI coding assistant via the Avo MCP; if you'd rather stay in the Avo app, the "Create more" toggle and the workbench let you create events in rapid succession.
 
-For creating multiple events quickly, Avo offers two streamlined approaches:
+#### From AI coding assistants (MCP)
+
+If you use Claude, Cursor, Codex, Claude Code, or another MCP-compatible client, you can create events directly from your AI assistant via the [Avo MCP](/reference/avo-mcp/overview). All writes happen on a branch — the MCP never merges to main.
+
+- Create a new branch with the [`workflow`](/reference/avo-mcp/tools#workflow) tool
+- Create events (with description, sources, and attached properties) on that branch with [`save_items`](/reference/avo-mcp/tools#save_items)
+- Create new events and new properties in a single batched call using [temporary IDs](/reference/avo-mcp/tools#temporary-ids-tempid--tmp)
+- Update an event's description, properties, or sources with `save_items` `op: "update"`
+
+<Callout type="info" emoji="🚧">
+  The Avo MCP is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
+</Callout>
 
 #### Batch creation with "Create more" toggle
 
@@ -52,19 +63,6 @@ From the workbench interface, you can create events inline:
 2. Enter your event name inline
 3. Hit Enter to create and immediately add another event
 4. Use Tab to navigate between inline creation fields
-
-### From AI coding assistants (MCP)
-
-If you use Claude, Cursor, Codex, Claude Code, or another MCP-compatible client, you can create events directly from your AI assistant via the [Avo MCP](/reference/avo-mcp/overview). All writes happen on a branch — the MCP never merges to main.
-
-- Create a new branch with the [`workflow`](/reference/avo-mcp/tools#workflow) tool
-- Create events (with description, sources, and attached properties) on that branch with [`save_items`](/reference/avo-mcp/tools#save_items)
-- Create new events and new properties in a single batched call using [temporary IDs](/reference/avo-mcp/tools#temporary-ids-tempid--tmp)
-- Update an event's description, properties, or sources with `save_items` `op: "update"`
-
-<Callout type="info" emoji="🚧">
-  The Avo MCP is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
-</Callout>
 
 ### Adding context with bulk editing
 

--- a/pages/data-design/avo-tracking-plan/events.mdx
+++ b/pages/data-design/avo-tracking-plan/events.mdx
@@ -34,7 +34,7 @@ Avo provides several ways to create events efficiently, depending on your workfl
 
 ### Fast event creation methods
 
-Fast creation methods are particularly useful when planning a new feature that requires multiple new events. The fastest option is to drive an AI coding assistant via the Avo MCP; if you'd rather stay in the Avo app, the "Create more" toggle and the workbench let you create events in rapid succession.
+Fast creation methods are particularly useful when planning a new feature that requires multiple new events. The fastest option is to drive an AI coding assistant via the Avo MCP; if you'd rather stay in the Avo app, the "Create more" toggle and inline creation in the workbench let you create events in rapid succession.
 
 #### From AI coding assistants (MCP)
 
@@ -42,8 +42,8 @@ If you use Claude, Cursor, Codex, Claude Code, or another MCP-compatible client,
 
 - Create a new branch with the [`workflow`](/reference/avo-mcp/tools#workflow) tool
 - Create events (with description, sources, and attached properties) on that branch with [`save_items`](/reference/avo-mcp/tools#save_items)
-- Create new events and new properties in a single batched call using [temporary IDs](/reference/avo-mcp/tools#temporary-ids-tempid--tmp)
-- Update an event's description, properties, or sources with `save_items` `op: "update"`
+- Create new events and new properties in a single batched call
+- Update an event's description, properties, or sources with [`save_items`](/reference/avo-mcp/tools#save_items) `op: "update"`
 
 <Callout type="info" emoji="🚧">
   The Avo MCP is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.

--- a/pages/data-design/avo-tracking-plan/events.mdx
+++ b/pages/data-design/avo-tracking-plan/events.mdx
@@ -53,6 +53,19 @@ From the workbench interface, you can create events inline:
 3. Hit Enter to create and immediately add another event
 4. Use Tab to navigate between inline creation fields
 
+### From AI coding assistants (MCP)
+
+If you use Claude, Cursor, Codex, Claude Code, or another MCP-compatible client, you can create events directly from your AI assistant via the [Avo MCP](/reference/avo-mcp/overview). All writes happen on a branch — the MCP never merges to main.
+
+- Create a new branch with the [`workflow`](/reference/avo-mcp/tools#workflow) tool
+- Create events (with description, sources, and attached properties) on that branch with [`save_items`](/reference/avo-mcp/tools#save_items)
+- Create new events and new properties in a single batched call using [temporary IDs](/reference/avo-mcp/tools#temporary-ids-tempid--tmp)
+- Update an event's description, properties, or sources with `save_items` `op: "update"`
+
+<Callout type="warning" emoji="🚧">
+  Write access to the Avo MCP is in closed beta. [Email support@avo.app](mailto:support@avo.app) to enable it for your workspace. Read tools (`get`, `search`, branch inspection) are generally available.
+</Callout>
+
 ### Adding context with bulk editing
 
 After creating multiple events using the fast creation methods, you can efficiently add context to all of them at once using **[bulk editing](/data-design/guides/bulk-editing)**. Simply:

--- a/pages/data-design/avo-tracking-plan/events.mdx
+++ b/pages/data-design/avo-tracking-plan/events.mdx
@@ -62,8 +62,8 @@ If you use Claude, Cursor, Codex, Claude Code, or another MCP-compatible client,
 - Create new events and new properties in a single batched call using [temporary IDs](/reference/avo-mcp/tools#temporary-ids-tempid--tmp)
 - Update an event's description, properties, or sources with `save_items` `op: "update"`
 
-<Callout type="warning" emoji="🚧">
-  Write access to the Avo MCP is in closed beta. [Email support@avo.app](mailto:support@avo.app) to enable it for your workspace. Read tools (`get`, `search`, branch inspection) are generally available.
+<Callout type="info" emoji="🚧">
+  The Avo MCP is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
 </Callout>
 
 ### Adding context with bulk editing

--- a/pages/data-design/avo-tracking-plan/properties.mdx
+++ b/pages/data-design/avo-tracking-plan/properties.mdx
@@ -10,6 +10,49 @@ Properties are also known as traits, attributes, metadata, etc. They are informa
 Looking for ways to organize properties and reuse them across events? See [Organizing your tracking plan](/data-design/guides/organizing-metrics-and-events)—especially [tags](/data-design/guides/organizing-metrics-and-events#tags), [categories](/data-design/guides/organizing-metrics-and-events#categories), [property bundles](/data-design/guides/organizing-metrics-and-events#property-bundles), and how these relate to [metrics](/data-design/guides/organizing-metrics-and-events#metrics).
 </Callout>
 
+## Creating properties
+
+Avo provides several ways to create properties, depending on whether you're designing in the context of an event or curating the property library directly.
+
+<Callout type="info" emoji="💡">When creating a new property you will receive guidance on how to name the property in a way that adheres to the [naming convention](/audit/advanced-event-naming-rules) defined for your workspace.</Callout>
+
+### Standard property creation methods
+
+- **Properties view creation button**: Click `+ Add Property` at the top of the Properties view to create event, user, or system properties in the property library
+- **From event details ("+ Add Event Property")**: From the Log Event action of an event, click `+ Add Event Property` and start typing a name — if no match exists, Avo offers to create a new property in place (see [creating new properties from event details](/data-design/start-data-design#step-1-create-a-new-event-property))
+- **Command palette**: Hit `C` on your keyboard and select "Property" from the command palette
+- **Group types and group properties**: see [Creating Group Types](#creating-group-types) and [Creating Group properties](#creating-group-properties) below for group-scoped properties
+- **From metrics**: Properties can also be created inline when defining a [metric](/data-design/avo-tracking-plan/metrics) filter or group-by
+
+### Fast property creation methods
+
+For creating multiple properties quickly, Avo offers streamlined approaches:
+
+#### Inline creation from event details
+
+When adding properties to events, you can chain creations from the "+ Add Event Property" flow — Avo audits the name as you type and offers to create new properties without leaving the event details.
+
+#### Workbench inline creation
+
+From the [workbench](/data-design/avo-tracking-plan/workbench), edit events inline and create new properties on the fly while you shape the event's payload.
+
+### From AI coding assistants (MCP)
+
+If you use Claude, Cursor, Codex, Claude Code, or another MCP-compatible client, you can create properties directly from your AI assistant via the [Avo MCP](/reference/avo-mcp/overview). All writes happen on a branch — the MCP never merges to main.
+
+- Create a new branch with the [`workflow`](/reference/avo-mcp/tools#workflow) tool
+- Create event, user, or system properties on that branch with [`save_items`](/reference/avo-mcp/tools#save_items), including type, `sendAs`, and description in a single call
+- Cross-reference newly-created properties to newly-created events in the same batch using [temporary IDs](/reference/avo-mcp/tools#temporary-ids-tempid--tmp)
+- Add allowed values, change a property's description or type, or remove a property — all via `save_items` `op: "update"` / `op: "remove"`
+
+<Callout type="warning" emoji="🚧">
+  Write access to the Avo MCP is in closed beta. [Email support@avo.app](mailto:support@avo.app) to enable it for your workspace. Read tools (`get`, `search`, branch inspection) are generally available.
+</Callout>
+
+### Adding context with bulk editing
+
+After creating multiple properties, you can attach shared context across them at once using **[bulk editing](/data-design/guides/bulk-editing)** — for example, applying common tags, categories, or stakeholders to a group of newly-created properties.
+
 ## Property Definition
 
 A property is defined in the event details within the relevant [actions](/data-design/avo-tracking-plan/events#actions) or in the properties view.

--- a/pages/data-design/avo-tracking-plan/properties.mdx
+++ b/pages/data-design/avo-tracking-plan/properties.mdx
@@ -26,17 +26,9 @@ Avo provides several ways to create properties, depending on whether you're desi
 
 ### Fast property creation methods
 
-For creating multiple properties quickly, Avo offers streamlined approaches:
+For creating multiple properties quickly, Avo offers streamlined approaches. The fastest option is to drive an AI coding assistant via the Avo MCP; if you'd rather stay in the Avo app, you can chain creations inline from event details or the workbench.
 
-#### Inline creation from event details
-
-When adding properties to events, you can chain creations from the "+ Add Event Property" flow — Avo audits the name as you type and offers to create new properties without leaving the event details.
-
-#### Workbench inline creation
-
-From the [workbench](/data-design/avo-tracking-plan/workbench), edit events inline and create new properties on the fly while you shape the event's payload.
-
-### From AI coding assistants (MCP)
+#### From AI coding assistants (MCP)
 
 If you use Claude, Cursor, Codex, Claude Code, or another MCP-compatible client, you can create properties directly from your AI assistant via the [Avo MCP](/reference/avo-mcp/overview). All writes happen on a branch — the MCP never merges to main.
 
@@ -48,6 +40,14 @@ If you use Claude, Cursor, Codex, Claude Code, or another MCP-compatible client,
 <Callout type="info" emoji="🚧">
   The Avo MCP is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
 </Callout>
+
+#### Inline creation from event details
+
+When adding properties to events, you can chain creations from the "+ Add Event Property" flow — Avo audits the name as you type and offers to create new properties without leaving the event details.
+
+#### Workbench inline creation
+
+From the [workbench](/data-design/avo-tracking-plan/workbench), edit events inline and create new properties on the fly while you shape the event's payload.
 
 ### Adding context with bulk editing
 

--- a/pages/data-design/avo-tracking-plan/properties.mdx
+++ b/pages/data-design/avo-tracking-plan/properties.mdx
@@ -45,8 +45,8 @@ If you use Claude, Cursor, Codex, Claude Code, or another MCP-compatible client,
 - Cross-reference newly-created properties to newly-created events in the same batch using [temporary IDs](/reference/avo-mcp/tools#temporary-ids-tempid--tmp)
 - Add allowed values, change a property's description or type, or remove a property — all via `save_items` `op: "update"` / `op: "remove"`
 
-<Callout type="warning" emoji="🚧">
-  Write access to the Avo MCP is in closed beta. [Email support@avo.app](mailto:support@avo.app) to enable it for your workspace. Read tools (`get`, `search`, branch inspection) are generally available.
+<Callout type="info" emoji="🚧">
+  The Avo MCP is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
 </Callout>
 
 ### Adding context with bulk editing

--- a/pages/data-design/avo-tracking-plan/properties.mdx
+++ b/pages/data-design/avo-tracking-plan/properties.mdx
@@ -33,9 +33,9 @@ For creating multiple properties quickly, Avo offers streamlined approaches. The
 If you use Claude, Cursor, Codex, Claude Code, or another MCP-compatible client, you can create properties directly from your AI assistant via the [Avo MCP](/reference/avo-mcp/overview). All writes happen on a branch — the MCP never merges to main.
 
 - Create a new branch with the [`workflow`](/reference/avo-mcp/tools#workflow) tool
-- Create event, user, or system properties on that branch with [`save_items`](/reference/avo-mcp/tools#save_items), including type, `sendAs`, and description in a single call
-- Cross-reference newly-created properties to newly-created events in the same batch using [temporary IDs](/reference/avo-mcp/tools#temporary-ids-tempid--tmp)
-- Add allowed values, change a property's description or type, or remove a property — all via `save_items` `op: "update"` / `op: "remove"`
+- Create event, user, or system properties on that branch with [`save_items`](/reference/avo-mcp/tools#save_items)
+- Cross-reference newly-created properties to newly-created events in the same batch
+- Add allowed values, change a property's description or type, or remove a property — all via [`save_items`](/reference/avo-mcp/tools#save_items) `op: "update"` / `op: "remove"`
 
 <Callout type="info" emoji="🚧">
   The Avo MCP is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.

--- a/pages/data-design/quick-start.mdx
+++ b/pages/data-design/quick-start.mdx
@@ -63,7 +63,7 @@ Open a new branch by clicking the icon next to "main" in the left sidebar. Then 
 
 ## Step 4: Make changes to your tracking plan
 
-When you've created the branch, you have two approaches to design your tracking:
+When you've created the branch, you have three approaches to design your tracking:
 
 ### Option A: Design with Journeys (recommended)
 
@@ -81,7 +81,15 @@ To create a journey, navigate to the _Journeys_ tab in the left sidebar and clic
   href="/data-design/avo-tracking-plan/journeys"
 />
 
-### Option B: Create events directly
+### Option B: Create from your AI coding assistant (fastest)
+
+If you use Claude, Cursor, Codex, Claude Code, or another MCP-compatible client, the [Avo MCP](/reference/avo-mcp/overview) lets your AI assistant create events and properties on your branch via [`save_items`](/reference/avo-mcp/tools#save_items). The MCP creates and writes to branches but never merges — review and merge stay in the [Avo web app](https://www.avo.app).
+
+<Callout type="info" emoji="🚧">
+  The Avo MCP is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
+</Callout>
+
+### Option C: Create events directly
 
 Alternatively, navigate to the _Events_ tab in the tracking plan to create events directly. Click the _+ Add Event_ button to create a new [event](/data-design/avo-tracking-plan/events).
 
@@ -116,14 +124,6 @@ In the event details, complete the definition of your event by filling in each s
 <br />
 
 New and modified events are highlighted in the [workbench](/data-design/avo-tracking-plan/workbench) at the top of your tracking plan events view, so you can easily access and have overview of your new and modified events.
-
-### Option C: Create from your AI coding assistant
-
-If you'd rather drive Claude, Cursor, Codex, Claude Code, or another MCP-compatible client, the [Avo MCP](/reference/avo-mcp/overview) lets your AI assistant create events and properties on your branch via [`save_items`](/reference/avo-mcp/tools#save_items). The MCP creates and writes to branches but never merges — review and merge stay in the [Avo web app](https://www.avo.app).
-
-<Callout type="info" emoji="🚧">
-  The Avo MCP is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
-</Callout>
 
 ## Step 5: Invite a colleague and ask them for a review
 

--- a/pages/data-design/quick-start.mdx
+++ b/pages/data-design/quick-start.mdx
@@ -117,6 +117,14 @@ In the event details, complete the definition of your event by filling in each s
 
 New and modified events are highlighted in the [workbench](/data-design/avo-tracking-plan/workbench) at the top of your tracking plan events view, so you can easily access and have overview of your new and modified events.
 
+### Option C: Create from your AI coding assistant
+
+If you'd rather drive Claude, Cursor, Codex, Claude Code, or another MCP-compatible client, the [Avo MCP](/reference/avo-mcp/overview) lets your AI assistant create events and properties on your branch via [`save_items`](/reference/avo-mcp/tools#save_items). The MCP creates and writes to branches but never merges — review and merge stay in the [Avo web app](https://www.avo.app).
+
+<Callout type="warning" emoji="🚧">
+  Write access to the Avo MCP is in closed beta. [Email support@avo.app](mailto:support@avo.app) to enable it for your workspace.
+</Callout>
+
 ## Step 5: Invite a colleague and ask them for a review
 
 Now we're ready to share our suggestions with our team, and ask them for input. Go to your workspace settings and invite a team member. Workspace members can be one of admin, editor, comment only or view only. To learn more about members and roles, check out our [members docs](/data-design/collaboration/members).

--- a/pages/data-design/quick-start.mdx
+++ b/pages/data-design/quick-start.mdx
@@ -121,8 +121,8 @@ New and modified events are highlighted in the [workbench](/data-design/avo-trac
 
 If you'd rather drive Claude, Cursor, Codex, Claude Code, or another MCP-compatible client, the [Avo MCP](/reference/avo-mcp/overview) lets your AI assistant create events and properties on your branch via [`save_items`](/reference/avo-mcp/tools#save_items). The MCP creates and writes to branches but never merges — review and merge stay in the [Avo web app](https://www.avo.app).
 
-<Callout type="warning" emoji="🚧">
-  Write access to the Avo MCP is in closed beta. [Email support@avo.app](mailto:support@avo.app) to enable it for your workspace.
+<Callout type="info" emoji="🚧">
+  The Avo MCP is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
 </Callout>
 
 ## Step 5: Invite a colleague and ask them for a review

--- a/pages/data-design/start-data-design.mdx
+++ b/pages/data-design/start-data-design.mdx
@@ -14,9 +14,9 @@ import { Callout } from 'nextra/components';
 - The basic concepts in Avo and event design
 - What to look out for when designing data
 
-## Two approaches to data design
+## Approaches to data design
 
-There are two main approaches to designing your tracking in Avo:
+There are three main approaches to designing your tracking in Avo:
 
 ### Visual design with Journeys (recommended)
 
@@ -33,7 +33,20 @@ The traditional approach covered in this guide involves creating metrics, events
 - Defining metrics independently of a specific feature
 - Making small updates to your tracking plan like adding a new allowed value to a string property
 
-Both approaches result in the same tracking plan structures—journeys simply provide a visual layer for designing and reviewing tracking in context.
+All three approaches result in the same tracking plan structures—Journeys provides a visual layer for designing and reviewing tracking in context, and the Avo MCP lets you drive changes from an AI coding assistant.
+
+### From your AI coding assistant (Avo MCP)
+
+If you use Claude, Cursor, Codex, Claude Code, or another MCP-compatible client, the [Avo MCP](/reference/avo-mcp/overview) lets your AI assistant create and update events, properties, and event variants on a branch in your workspace. This approach is useful when:
+- You want to draft tracking changes alongside the code that emits them
+- You'd rather describe the change in natural language than click through the UI
+- You're already in a coding agent that has context about the feature you're shipping
+
+The MCP creates and writes to branches via [`workflow`](/reference/avo-mcp/tools#workflow) and [`save_items`](/reference/avo-mcp/tools#save_items) but never merges to main — review and merge stay a human step in the [Avo web app](https://www.avo.app).
+
+<Callout type="warning" emoji="🚧">
+  Write access to the Avo MCP is in closed beta. [Email support@avo.app](mailto:support@avo.app) to enable it for your workspace.
+</Callout>
 
 ## Defining a metric
 

--- a/pages/data-design/start-data-design.mdx
+++ b/pages/data-design/start-data-design.mdx
@@ -44,8 +44,8 @@ If you use Claude, Cursor, Codex, Claude Code, or another MCP-compatible client,
 
 The MCP creates and writes to branches via [`workflow`](/reference/avo-mcp/tools#workflow) and [`save_items`](/reference/avo-mcp/tools#save_items) but never merges to main — review and merge stay a human step in the [Avo web app](https://www.avo.app).
 
-<Callout type="warning" emoji="🚧">
-  Write access to the Avo MCP is in closed beta. [Email support@avo.app](mailto:support@avo.app) to enable it for your workspace.
+<Callout type="info" emoji="🚧">
+  The Avo MCP is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
 </Callout>
 
 ## Defining a metric

--- a/pages/data-design/start-data-design.mdx
+++ b/pages/data-design/start-data-design.mdx
@@ -27,15 +27,7 @@ There are three main approaches to designing your tracking in Avo:
 
 With journeys, you [Import from Figma](/data-design/avo-tracking-plan/journeys#importing-steps-from-figma) or drag and drop screenshots, add triggers for user actions, and connect them to events—all in a visual canvas. Learn more in our [Journeys documentation](/data-design/avo-tracking-plan/journeys).
 
-### Direct event and metric creation
-
-The traditional approach covered in this guide involves creating metrics, events, and properties directly in their respective views. This is useful when:
-- Defining metrics independently of a specific feature
-- Making small updates to your tracking plan like adding a new allowed value to a string property
-
-All three approaches result in the same tracking plan structures—Journeys provides a visual layer for designing and reviewing tracking in context, and the Avo MCP lets you drive changes from an AI coding assistant.
-
-### From your AI coding assistant (Avo MCP)
+### From your AI coding assistant (Avo MCP, fastest)
 
 If you use Claude, Cursor, Codex, Claude Code, or another MCP-compatible client, the [Avo MCP](/reference/avo-mcp/overview) lets your AI assistant create and update events, properties, and event variants on a branch in your workspace. This approach is useful when:
 - You want to draft tracking changes alongside the code that emits them
@@ -47,6 +39,14 @@ The MCP creates and writes to branches via [`workflow`](/reference/avo-mcp/tools
 <Callout type="info" emoji="🚧">
   The Avo MCP is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
 </Callout>
+
+### Direct event and metric creation
+
+The traditional approach covered in this guide involves creating metrics, events, and properties directly in their respective views. This is useful when:
+- Defining metrics independently of a specific feature
+- Making small updates to your tracking plan like adding a new allowed value to a string property
+
+All three approaches result in the same tracking plan structures—Journeys provides a visual layer for designing and reviewing tracking in context, and the Avo MCP lets you drive changes from an AI coding assistant.
 
 ## Defining a metric
 


### PR DESCRIPTION
## Summary

- Adds discoverability for the Avo MCP from the four data-design pages a new user is most likely to land on
- Creates the missing "Creating properties" section on `properties.mdx`, mirroring the existing "Creating events" section
- MCP gets a dedicated subsection (peer to "Standard…" / "Fast…") on the per-item docs, and a peer-level slot in the quick-start options and the deep-dive intro

## Pages touched

- `data-design/avo-tracking-plan/properties.mdx` — new `## Creating properties` section with Standard / Fast / MCP / Bulk editing subsections
- `data-design/avo-tracking-plan/events.mdx` — new `### From AI coding assistants (MCP)` subsection inside `## Creating events`
- `data-design/quick-start.mdx` — new `### Option C: Create from your AI coding assistant` in Step 4 alongside Journeys and Direct creation
- `data-design/start-data-design.mdx` — renamed "Two approaches" → "Approaches", added MCP as a third peer approach in the intro

Each new section links to `/reference/avo-mcp/overview` plus `#workflow`, `#save_items`, and the temp-IDs anchor where relevant, and carries a one-line closed-beta callout for writes.

## Test plan

- [ ] Run `yarn dev` and visit each updated page — confirm headings, callouts, and bullet lists render
- [ ] Click every new `/reference/avo-mcp/...` link and confirm anchors resolve (especially `#temporary-ids-tempid--tmp`, which is a github-slugger derivation of the heading in `tools.mdx`)
- [ ] Spot-check `+ Add Property` button label and `C` command-palette letter against the live Avo app — both mirror the existing events-page wording but worth a quick visual confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guides for creating events and properties, adding AI-assisted creation via the Avo MCP
  * Added workflow guidance for using AI assistants with MCP (branch-based flow)
  * Included MCP beta-status callout and support contact for issues
  * Updated quickstart and intro content to reflect three available creation approaches

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avohq/docs/pull/1701)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->