### PR TITLE
Polish Avo MCP overview docs for catalog submission

### DIFF
--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -211,50 +211,102 @@ also **Signup Started**, fired when the signup screen opens. Want a closer
 look at either?
 ```
 
-### Create a property on a branch
+### Design tracking for a new feature
 
 ```text
-You: Add a Checkout Method property to the Checkout Completed event.
+You: We're adding social sharing to the post detail screen — Twitter,
+LinkedIn, or copy link. Design the tracking for it.
 
-Claude: I'll create a branch, add the property, and attach it to the event.
-You'll see a one-time re-auth prompt for write access in your browser.
+Claude: I'll check the workspace's audit rules, see what already exists,
+and propose a plan before touching a branch.
 
-Claude → workflow({
-  action: "create_branch",
-  branchName: "add-checkout-method"
+Claude → get({ type: "workspaceConfig" })
+
+Server ← {
+  "eventNaming": {
+    "structure": "object-action",
+    "casing": "Title Case",
+    "tense": "past"
+  },
+  "propertyNaming": { "casing": "Title Case" },
+  "rules": [
+    "Event names must end in a past-tense verb",
+    "Property names must be descriptive (e.g. Product Name, not Product)"
+  ]
+}
+
+Claude → search({ query: "share", itemType: "event", maxResults: 5 })
+
+Server ← {
+  "results": [
+    {
+      "rank": 1,
+      "name": "Article Shared",
+      "itemType": "event",
+      "itemId": "evt-7c91...",
+      "relevance": 0.84,
+      "description": "Sent when a user shares an article from the feed..."
+    }
+  ]
+}
+
+Claude → search({
+  itemType: "property",
+  eventNames: ["Article Shared"]
 })
 
 Server ← {
-  "branchId": "br-7d2f...",
-  "branchName": "add-checkout-method",
-  "branchUrl": "https://www.avo.app/schemas/default/branches/br-7d2f..."
+  "results": [
+    { "name": "Share Method", "itemId": "prop-2a08...", "itemType": "property" },
+    { "name": "Share Destination", "itemId": "prop-8b13...", "itemType": "property" }
+  ]
 }
 
-Claude → get({ type: "event", name: "Checkout Completed" })
+Claude: Here's the plan, anchored on a **Post Share Rate** metric:
+
+**Reuse**
+- `Share Method` (string: Twitter, LinkedIn, Copy Link) — already on `Article Shared`
+- `Share Destination` — same shape we need
+
+**Create**
+- **Post Shared** event — sent when a user shares a post from the post detail screen
+- **Post ID** property (string, event) — the ID of the post being shared
+
+Matches the workspace convention (Title Case, object-action, past tense).
+Proceed with the branch?
+
+You: yes
+
+Claude → workflow({
+  action: "create_branch",
+  branchName: "add-post-sharing-tracking"
+})
 
 Server ← {
-  "name": "Checkout Completed",
-  "id": "evt-c2a8...",
-  "description": "Sent when the user successfully completes a checkout."
+  "branchId": "br-4e8a...",
+  "branchName": "add-post-sharing-tracking",
+  "branchUrl": "https://www.avo.app/schemas/default/branches/br-4e8a..."
 }
 
 Claude → save_items({
-  branchId: "br-7d2f...",
+  branchId: "br-4e8a...",
   items: [
     {
       op: "create",
       type: "property",
-      tempId: "checkout_method",
-      name: "Checkout Method",
+      tempId: "post_id",
+      name: "Post ID",
       propertyType: "string",
       sendAs: "event",
-      description: "How the user completed checkout (Apple Pay, Google Pay, Card)"
+      description: "The ID of the post being shared."
     },
     {
-      op: "update",
+      op: "create",
       type: "event",
-      eventId: "evt-c2a8...",
-      addProperties: ["$tmp:checkout_method"]
+      name: "Post Shared",
+      description: "Sent when a user shares a post from the post detail screen.",
+      properties: ["$tmp:post_id", "prop-2a08...", "prop-8b13..."],
+      sources: ["src-ios", "src-android", "src-web"]
     }
   ]
 })
@@ -262,52 +314,108 @@ Claude → save_items({
 Server ← {
   "success": true,
   "createdEntities": [
-    {
-      "name": "Checkout Method",
-      "entityId": "prop-44e1...",
-      "entityType": "property"
-    }
+    { "name": "Post ID", "entityId": "prop-9d44...", "entityType": "property" },
+    { "name": "Post Shared", "entityId": "evt-3f01...", "entityType": "event" }
   ],
-  "updatedEntities": [
-    {
-      "name": "Checkout Completed",
-      "entityId": "evt-c2a8...",
-      "entityType": "event"
-    }
-  ],
+  "updatedEntities": [],
   "removedEntities": [],
   "errors": [],
   "warnings": []
 }
 
-Claude: Done. **Checkout Method** (string, event property) is created and
-attached to **Checkout Completed** on the branch
-[`add-checkout-method`](https://www.avo.app/schemas/default/branches/br-7d2f...).
-Open the branch in the Avo app to review and merge to main — merging stays
-a human step.
+Claude: Done. Branch
+[`add-post-sharing-tracking`](https://www.avo.app/schemas/default/branches/br-4e8a...)
+has the new **Post Shared** event with one new property (**Post ID**) and two
+reused ones (**Share Method**, **Share Destination**). Open the branch in
+the Avo app to review and merge to main.
 ```
 
-### Open a new branch
+### Review and implement a branch in code
 
 ```text
-You: Open a new branch called update-signup-flow.
+You: I'm implementing the update-signup-flow branch on iOS. Walk me through it.
 
-Claude: You'll see a one-time re-auth prompt for write access in your browser.
+Claude → list_branches({ branchName: "update-signup-flow" })
 
-Claude → workflow({
-  action: "create_branch",
-  branchName: "update-signup-flow"
+Server ← {
+  "branches": [
+    {
+      "branchId": "br-6c2d...",
+      "branchName": "update-signup-flow",
+      "status": "Approved",
+      "creator": "alex@example.com"
+    }
+  ]
+}
+
+Claude → get_branch_implementation_guide({ branchId: "br-6c2d..." })
+
+Server ← {
+  "summary": { "newEvents": 1, "modifiedEvents": 1, "deletedEvents": 0 },
+  "newEvents": [
+    {
+      "name": "Signup Step Completed",
+      "description": "Sent when the user completes a step in the signup funnel.",
+      "properties": ["Signup Step", "Step Outcome"],
+      "implementationType": "Codegen"
+    }
+  ],
+  "modifiedEvents": [
+    {
+      "name": "Signup Completed",
+      "changes": [
+        { "field": "properties", "added": ["Authentication Method"] }
+      ],
+      "implementationType": "Codegen"
+    }
+  ]
+}
+
+Claude → get_sources({})
+
+Server ← {
+  "sources": [
+    { "name": "iOS", "sourceId": "src-ios", "language": "Swift", "platform": "iOS" },
+    { "name": "Android", "sourceId": "src-android", "language": "Kotlin", "platform": "Android" },
+    { "name": "Web", "sourceId": "src-web", "language": "TypeScript", "platform": "Web" }
+  ]
+}
+
+Claude → get_branch_code_snippets({
+  branchId: "br-6c2d...",
+  sourceId: "src-ios"
 })
 
 Server ← {
-  "branchId": "br-1a4c...",
-  "branchName": "update-signup-flow",
-  "branchUrl": "https://www.avo.app/schemas/default/branches/br-1a4c..."
+  "snippets": [
+    {
+      "event": "Signup Step Completed",
+      "status": "New",
+      "label": "Codegen",
+      "diff": "+ Avo.signupStepCompleted(signupStep: ..., stepOutcome: ...)"
+    },
+    {
+      "event": "Signup Completed",
+      "status": "Updated",
+      "label": "Codegen",
+      "diff": "- Avo.signupCompleted()\n+ Avo.signupCompleted(authenticationMethod: ...)"
+    }
+  ]
 }
 
-Claude: Branch
-[`update-signup-flow`](https://www.avo.app/schemas/default/branches/br-1a4c...)
-is ready. What changes do you want to make on it?
+Claude: Here's what's on `update-signup-flow` for iOS:
+
+**1 new event** — `Signup Step Completed` (Codegen)
+**1 modified event** — `Signup Completed` gains an `Authentication Method` property
+(Codegen)
+
+The iOS source uses Avo Codegen, so the next step is to run `avo pull` locally
+to regenerate `Avo.swift`, then update each call site:
+
+- Add `Avo.signupStepCompleted(...)` at each signup-step transition
+- Pass `authenticationMethod` to existing `Avo.signupCompleted()` calls
+
+Want me to find the call sites in the iOS project, or are you good from here?
 ```
 
 ## Troubleshooting

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -121,7 +121,7 @@ Pass `workspaceId` to every workspace-scoped tool. (Stdio clients can also set t
 
 ## Example workflows
 
-The connector's core flows, each with a concrete example. Tool calls are shown as `tool(arguments)`; sample JSON shows the response shape. Real responses include the full item shape documented in the [Tools reference](/reference/avo-mcp/tools).
+The connector's core flows, each with a concrete example. Tool calls are written inline as `tool(arguments)`; the JSON blocks show what success looks like. Real responses include the full item shape documented in the [Tools reference](/reference/avo-mcp/tools).
 
 ### Discover what's in the plan
 
@@ -131,12 +131,11 @@ Use `search` for fuzzy lookup by meaning ("user signed up" matches `Account Crea
   Semantic search requires Avo Intelligence Smart Search to be enabled in your workspace. Workspace admins can enable it in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). Without it, fall back to `get` with an exact name.
 </Callout>
 
-```text
-You: What events do we have for signup?
+**You:** What events do we have for signup?
 
-Claude calls search({ query: "signup", itemType: "event" }).
+Claude calls `search({ query: "signup", itemType: "event" })`. Returns:
 
-Returns:
+```json
 {
   "results": [
     {
@@ -155,28 +154,23 @@ Returns:
     }
   ]
 }
-
-Claude then calls get({ type: "event", id: "evt-9f2b...", includePropertyDetails: true }) for the full shape, and replies:
-
-You have two signup events. The closest match is **Account Created** —
-sent when a user successfully creates an account — with properties
-Authentication Method (Email, Google, Apple) and Referral Source. There's
-also **Signup Started**, fired when the signup screen opens. Want a closer
-look at either?
 ```
+
+Claude then calls `get({ type: "event", id: "evt-9f2b...", includePropertyDetails: true })` for the full shape, and replies:
+
+**Claude:** You have two signup events. The closest match is **Account Created** — sent when a user successfully creates an account — with properties Authentication Method (Email, Google, Apple) and Referral Source. There's also **Signup Started**, fired when the signup screen opens. Want a closer look at either?
 
 ### Design tracking for a new feature
 
 The flagship write flow. Claude reads the workspace's audit rules with `get(workspaceConfig)`, does both-lenses recon (semantic `search` and structural-filter `search`) to find what already exists, proposes a plan, and on approval creates a branch with `workflow` and writes the new items in a single batched `save_items` call — using `tempId` to attach a newly-created property to a newly-created event atomically.
 
-```text
-You: We're adding social sharing to the post detail screen — Twitter,
-LinkedIn, or copy link. Design the tracking for it.
+**You:** We're adding social sharing to the post detail screen — Twitter, LinkedIn, or copy link. Design the tracking for it.
 
-Claude: I'll check the workspace's audit rules, see what already exists,
-and propose a plan before touching a branch.
+**Claude:** I'll check the workspace's audit rules, see what already exists, and propose a plan before touching a branch.
 
-Claude calls get({ type: "workspaceConfig" }), which returns the workspace's naming and audit rules:
+Claude calls `get({ type: "workspaceConfig" })`, which returns the workspace's naming and audit rules:
+
+```json
 {
   "eventNaming": {
     "structure": "object-action",
@@ -188,10 +182,11 @@ Claude calls get({ type: "workspaceConfig" }), which returns the workspace's nam
     "Property names must be descriptive (e.g. Product Name, not Product)"
   ]
 }
+```
 
-Claude then searches for existing share-related events with search({ query: "share", itemType: "event" }), and lists the properties on the matched Article Shared event with search({ itemType: "property", eventNames: ["Article Shared"] }) — finding Share Method and Share Destination already exist.
+Claude then searches for existing share-related events with `search({ query: "share", itemType: "event" })`, and lists the properties on the matched `Article Shared` event with `search({ itemType: "property", eventNames: ["Article Shared"] })` — finding `Share Method` and `Share Destination` already exist.
 
-Claude: Here's the plan, anchored on a **Post Share Rate** metric:
+**Claude:** Here's the plan, anchored on a **Post Share Rate** metric:
 
 **Reuse**
 - `Share Method` (string: Twitter, LinkedIn, Copy Link) — already on `Article Shared`
@@ -201,14 +196,13 @@ Claude: Here's the plan, anchored on a **Post Share Rate** metric:
 - **Post Shared** event — sent when a user shares a post from the post detail screen
 - **Post ID** property (string, event) — the ID of the post being shared
 
-Matches the workspace convention (Title Case, object-action, past tense).
-Proceed with the branch?
+Matches the workspace convention (Title Case, object-action, past tense). Proceed with the branch?
 
-You: yes
+**You:** yes
 
-Claude calls workflow({ action: "create_branch", branchName: "add-post-sharing-tracking" }), then batches the new property and the new event in one save_items call. The event's properties array references the new property by "$tmp:post_id" alongside the real IDs of the two reused properties — the server resolves the temp ID into a real one and attaches everything atomically.
+Claude calls `workflow({ action: "create_branch", branchName: "add-post-sharing-tracking" })`, then batches the new property and the new event in one `save_items` call. The event's `properties` array references the new property by `"$tmp:post_id"` alongside the real IDs of the two reused properties — the server resolves the temp ID into a real one and attaches everything atomically. `save_items` returns:
 
-save_items returns:
+```json
 {
   "success": true,
   "createdEntities": [
@@ -220,23 +214,19 @@ save_items returns:
   "errors": [],
   "warnings": []
 }
-
-Claude: Done. Branch
-[`add-post-sharing-tracking`](https://www.avo.app/schemas/default/branches/br-4e8a...)
-has the new **Post Shared** event with one new property (**Post ID**) and
-two reused ones (**Share Method**, **Share Destination**). Open the branch
-in the Avo app to review and merge to main.
 ```
+
+**Claude:** Done. Branch [`add-post-sharing-tracking`](https://www.avo.app/schemas/default/branches/br-4e8a...) has the new **Post Shared** event with one new property (**Post ID**) and two reused ones (**Share Method**, **Share Destination**). Open the branch in the Avo app to review and merge to main.
 
 ### Review and implement a branch in code
 
 Resolve a branch by name with `list_branches`, read the high-level change set with `get_branch_implementation_guide`, then pull the per-event code diff for a specific source with `get_branch_code_snippets` (after looking up the `sourceId` via `get_sources`). Implementation handoff: the diff goes into the codebase, code review happens in git, and the human merges the Avo branch from the web app.
 
-```text
-You: I'm implementing the update-signup-flow branch on iOS. Walk me through it.
+**You:** I'm implementing the update-signup-flow branch on iOS. Walk me through it.
 
-Claude resolves the branch name with list_branches({ branchName: "update-signup-flow" }), then calls get_branch_implementation_guide({ branchId: "br-6c2d..." }):
+Claude resolves the branch name with `list_branches({ branchName: "update-signup-flow" })`, then calls `get_branch_implementation_guide({ branchId: "br-6c2d..." })`:
 
+```json
 {
   "summary": { "newEvents": 1, "modifiedEvents": 1, "deletedEvents": 0 },
   "newEvents": [
@@ -257,9 +247,11 @@ Claude resolves the branch name with list_branches({ branchName: "update-signup-
     }
   ]
 }
+```
 
-Claude looks up the iOS source with get_sources(), then pulls per-event code diffs with get_branch_code_snippets({ branchId: "br-6c2d...", sourceId: "src-ios" }):
+Claude looks up the iOS source with `get_sources()`, then pulls per-event code diffs with `get_branch_code_snippets({ branchId: "br-6c2d...", sourceId: "src-ios" })`:
 
+```json
 {
   "snippets": [
     {
@@ -276,21 +268,27 @@ Claude looks up the iOS source with get_sources(), then pulls per-event code dif
     }
   ]
 }
+```
 
-Claude: Here's what's on `update-signup-flow` for iOS:
+**Claude:** Here's what's on `update-signup-flow` for iOS:
 
 **1 new event** — `Signup Step Completed` (Codegen)
-**1 modified event** — `Signup Completed` gains an `Authentication Method`
-property (Codegen)
+**1 modified event** — `Signup Completed` gains an `Authentication Method` property (Codegen)
 
-The iOS source uses Avo Codegen, so the next step is to run `avo pull`
-locally to regenerate `Avo.swift`, then update each call site:
+The iOS source uses Avo Codegen, so the next step is to run `avo pull` locally to regenerate `Avo.swift`, then update each call site:
 
 - Add `Avo.signupStepCompleted(...)` at each signup-step transition
 - Pass `authenticationMethod` to existing `Avo.signupCompleted()` calls
 
 Want me to find the call sites in the iOS project, or are you good from here?
-```
+
+---
+
+This isn't a finite list of workflows — check out the [Tools reference](/reference/avo-mcp/tools) to explore what else is possible.
+
+## Tools
+
+See the [Tools reference](/reference/avo-mcp/tools) for the full list of tools and their parameters.
 
 ## Troubleshooting
 
@@ -311,7 +309,3 @@ Want me to find the call sites in the iOS project, or are you good from here?
 For bug reports, feature requests, or help connecting an MCP client, email [support@avo.app](mailto:support@avo.app).
 
 How Avo collects, uses, and retains data is covered in the [Avo Privacy Policy](https://www.avo.app/l/privacy).
-
-## Tools
-
-See the [Tools reference](/reference/avo-mcp/tools) for the full list of tools and their parameters.

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -119,55 +119,29 @@ Call `list_workspaces` to find your `workspaceId`.
 
 Pass `workspaceId` to every workspace-scoped tool. (Stdio clients can also set the `WORKSPACE_ID` environment variable so it's picked up automatically.)
 
-## Recommended agent flows
+## Example workflows
 
-### Explore the plan
+The connector's core flows, each with a concrete example. Tool calls are shown as `tool(arguments)`; sample JSON shows the response shape. Real responses include the full item shape documented in the [Tools reference](/reference/avo-mcp/tools).
 
-`list_workspaces` → `search` or `get` to inspect items by meaning or by ID/name.
+### Discover what's in the plan
 
-### Find work on a branch
-
-`list_branches` → `get_branch_details` → `get_branch_implementation_guide` → `get_branch_code_snippets` (with a `sourceId` from `get_sources`).
-
-### Add events for a new feature
-
-1. `workflow` with `action: "create_branch"` and a `branchName` → returns `branchId`.
-2. `save_items` on that `branchId` with a batch of `event` / `property` / `event_variant` items. Use `tempId` for forward references so a newly created property can be attached to a newly created event in a single call.
-3. Tell the user the branch is ready — the MCP does not merge. Open the branch in the [Avo web app](https://www.avo.app) (or ask a reviewer) to review and merge it to main.
-
-### Fix a property on an existing branch
-
-`list_branches` → `get_branch_details` to get `branchId` → `save_items` with `op: "update"` targeting an `eventId` or `propertyId`.
-
-### Searching for an event
-
-Use `search` to find events by meaning, not just exact name. A query like `"user signed up"` will match events named `Account Created` or `Registration Completed`.
+Use `search` for fuzzy lookup by meaning ("user signed up" matches `Account Created`), `get` for an exact name or ID, and structural-filter `search` (no `query`, just filter fields like `eventNames` or `properties`) to list items by relationship.
 
 <Callout type="info" emoji="🔒">
-  Semantic search requires Avo Intelligence Smart Search to be enabled in your workspace. Workspace admins can enable it in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). If you don't have admin access, ask a workspace admin to enable it.
+  Semantic search requires Avo Intelligence Smart Search to be enabled in your workspace. Workspace admins can enable it in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). Without it, fall back to `get` with an exact name.
 </Callout>
-
-## Example sessions
-
-The blocks below show what each major flow looks like end-to-end — the user prompt, the tool calls Claude makes, the JSON the server returns, and how Claude wraps up. JSON has been trimmed for readability; real responses include the full item shape documented in the [Tools reference](/reference/avo-mcp/tools).
-
-### Find events by meaning
 
 ```text
 You: What events do we have for signup?
 
-Claude → search({
-  query: "signup",
-  itemType: "event",
-  maxResults: 5
-})
+Claude calls search({ query: "signup", itemType: "event" }).
 
-Server ← {
+Returns:
+{
   "results": [
     {
       "rank": 1,
       "name": "Account Created",
-      "itemType": "event",
       "itemId": "evt-9f2b...",
       "relevance": 0.91,
       "description": "Sent when a new account is successfully created..."
@@ -175,7 +149,6 @@ Server ← {
     {
       "rank": 2,
       "name": "Signup Started",
-      "itemType": "event",
       "itemId": "evt-3c11...",
       "relevance": 0.87,
       "description": "Sent when the user opens the signup screen..."
@@ -183,35 +156,18 @@ Server ← {
   ]
 }
 
-Claude → get({
-  type: "event",
-  id: "evt-9f2b...",
-  includePropertyDetails: true
-})
+Claude then calls get({ type: "event", id: "evt-9f2b...", includePropertyDetails: true }) for the full shape, and replies:
 
-Server ← {
-  "name": "Account Created",
-  "id": "evt-9f2b...",
-  "description": "Sent when a new account is successfully created.",
-  "sources": ["iOS", "Android", "Web"],
-  "properties": [
-    {
-      "name": "Authentication Method",
-      "type": "string",
-      "allowedValues": ["Email", "Google", "Apple"]
-    },
-    { "name": "Referral Source", "type": "string" }
-  ]
-}
-
-Claude: You have two signup events. The closest match is **Account Created**
-— sent when a user successfully creates an account — with properties
+You have two signup events. The closest match is **Account Created** —
+sent when a user successfully creates an account — with properties
 Authentication Method (Email, Google, Apple) and Referral Source. There's
 also **Signup Started**, fired when the signup screen opens. Want a closer
 look at either?
 ```
 
 ### Design tracking for a new feature
+
+The flagship write flow. Claude reads the workspace's audit rules with `get(workspaceConfig)`, does both-lenses recon (semantic `search` and structural-filter `search`) to find what already exists, proposes a plan, and on approval creates a branch with `workflow` and writes the new items in a single batched `save_items` call — using `tempId` to attach a newly-created property to a newly-created event atomically.
 
 ```text
 You: We're adding social sharing to the post detail screen — Twitter,
@@ -220,47 +176,20 @@ LinkedIn, or copy link. Design the tracking for it.
 Claude: I'll check the workspace's audit rules, see what already exists,
 and propose a plan before touching a branch.
 
-Claude → get({ type: "workspaceConfig" })
-
-Server ← {
+Claude calls get({ type: "workspaceConfig" }), which returns the workspace's naming and audit rules:
+{
   "eventNaming": {
     "structure": "object-action",
     "casing": "Title Case",
     "tense": "past"
   },
-  "propertyNaming": { "casing": "Title Case" },
   "rules": [
     "Event names must end in a past-tense verb",
     "Property names must be descriptive (e.g. Product Name, not Product)"
   ]
 }
 
-Claude → search({ query: "share", itemType: "event", maxResults: 5 })
-
-Server ← {
-  "results": [
-    {
-      "rank": 1,
-      "name": "Article Shared",
-      "itemType": "event",
-      "itemId": "evt-7c91...",
-      "relevance": 0.84,
-      "description": "Sent when a user shares an article from the feed..."
-    }
-  ]
-}
-
-Claude → search({
-  itemType: "property",
-  eventNames: ["Article Shared"]
-})
-
-Server ← {
-  "results": [
-    { "name": "Share Method", "itemId": "prop-2a08...", "itemType": "property" },
-    { "name": "Share Destination", "itemId": "prop-8b13...", "itemType": "property" }
-  ]
-}
+Claude then searches for existing share-related events with search({ query: "share", itemType: "event" }), and lists the properties on the matched Article Shared event with search({ itemType: "property", eventNames: ["Article Shared"] }) — finding Share Method and Share Destination already exist.
 
 Claude: Here's the plan, anchored on a **Post Share Rate** metric:
 
@@ -277,41 +206,10 @@ Proceed with the branch?
 
 You: yes
 
-Claude → workflow({
-  action: "create_branch",
-  branchName: "add-post-sharing-tracking"
-})
+Claude calls workflow({ action: "create_branch", branchName: "add-post-sharing-tracking" }), then batches the new property and the new event in one save_items call. The event's properties array references the new property by "$tmp:post_id" alongside the real IDs of the two reused properties — the server resolves the temp ID into a real one and attaches everything atomically.
 
-Server ← {
-  "branchId": "br-4e8a...",
-  "branchName": "add-post-sharing-tracking",
-  "branchUrl": "https://www.avo.app/schemas/default/branches/br-4e8a..."
-}
-
-Claude → save_items({
-  branchId: "br-4e8a...",
-  items: [
-    {
-      op: "create",
-      type: "property",
-      tempId: "post_id",
-      name: "Post ID",
-      propertyType: "string",
-      sendAs: "event",
-      description: "The ID of the post being shared."
-    },
-    {
-      op: "create",
-      type: "event",
-      name: "Post Shared",
-      description: "Sent when a user shares a post from the post detail screen.",
-      properties: ["$tmp:post_id", "prop-2a08...", "prop-8b13..."],
-      sources: ["src-ios", "src-android", "src-web"]
-    }
-  ]
-})
-
-Server ← {
+save_items returns:
+{
   "success": true,
   "createdEntities": [
     { "name": "Post ID", "entityId": "prop-9d44...", "entityType": "property" },
@@ -325,32 +223,21 @@ Server ← {
 
 Claude: Done. Branch
 [`add-post-sharing-tracking`](https://www.avo.app/schemas/default/branches/br-4e8a...)
-has the new **Post Shared** event with one new property (**Post ID**) and two
-reused ones (**Share Method**, **Share Destination**). Open the branch in
-the Avo app to review and merge to main.
+has the new **Post Shared** event with one new property (**Post ID**) and
+two reused ones (**Share Method**, **Share Destination**). Open the branch
+in the Avo app to review and merge to main.
 ```
 
 ### Review and implement a branch in code
 
+Resolve a branch by name with `list_branches`, read the high-level change set with `get_branch_implementation_guide`, then pull the per-event code diff for a specific source with `get_branch_code_snippets` (after looking up the `sourceId` via `get_sources`). Implementation handoff: the diff goes into the codebase, code review happens in git, and the human merges the Avo branch from the web app.
+
 ```text
 You: I'm implementing the update-signup-flow branch on iOS. Walk me through it.
 
-Claude → list_branches({ branchName: "update-signup-flow" })
+Claude resolves the branch name with list_branches({ branchName: "update-signup-flow" }), then calls get_branch_implementation_guide({ branchId: "br-6c2d..." }):
 
-Server ← {
-  "branches": [
-    {
-      "branchId": "br-6c2d...",
-      "branchName": "update-signup-flow",
-      "status": "Approved",
-      "creator": "alex@example.com"
-    }
-  ]
-}
-
-Claude → get_branch_implementation_guide({ branchId: "br-6c2d..." })
-
-Server ← {
+{
   "summary": { "newEvents": 1, "modifiedEvents": 1, "deletedEvents": 0 },
   "newEvents": [
     {
@@ -371,22 +258,9 @@ Server ← {
   ]
 }
 
-Claude → get_sources({})
+Claude looks up the iOS source with get_sources(), then pulls per-event code diffs with get_branch_code_snippets({ branchId: "br-6c2d...", sourceId: "src-ios" }):
 
-Server ← {
-  "sources": [
-    { "name": "iOS", "sourceId": "src-ios", "language": "Swift", "platform": "iOS" },
-    { "name": "Android", "sourceId": "src-android", "language": "Kotlin", "platform": "Android" },
-    { "name": "Web", "sourceId": "src-web", "language": "TypeScript", "platform": "Web" }
-  ]
-}
-
-Claude → get_branch_code_snippets({
-  branchId: "br-6c2d...",
-  sourceId: "src-ios"
-})
-
-Server ← {
+{
   "snippets": [
     {
       "event": "Signup Step Completed",
@@ -406,11 +280,11 @@ Server ← {
 Claude: Here's what's on `update-signup-flow` for iOS:
 
 **1 new event** — `Signup Step Completed` (Codegen)
-**1 modified event** — `Signup Completed` gains an `Authentication Method` property
-(Codegen)
+**1 modified event** — `Signup Completed` gains an `Authentication Method`
+property (Codegen)
 
-The iOS source uses Avo Codegen, so the next step is to run `avo pull` locally
-to regenerate `Avo.swift`, then update each call site:
+The iOS source uses Avo Codegen, so the next step is to run `avo pull`
+locally to regenerate `Avo.swift`, then update each call site:
 
 - Add `Avo.signupStepCompleted(...)` at each signup-step transition
 - Pass `authenticationMethod` to existing `Avo.signupCompleted()` calls

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -147,6 +147,189 @@ Use `search` to find events by meaning, not just exact name. A query like `"user
   Semantic search requires Avo Intelligence Smart Search to be enabled in your workspace. Workspace admins can enable it in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). If you don't have admin access, ask a workspace admin to enable it.
 </Callout>
 
+## Example sessions
+
+The blocks below show what each major flow looks like end-to-end — the user prompt, the tool calls Claude makes, the JSON the server returns, and how Claude wraps up. JSON has been trimmed for readability; real responses include the full item shape documented in the [Tools reference](/reference/avo-mcp/tools).
+
+### Find events by meaning
+
+```text
+You: What events do we have for signup?
+
+Claude → search({
+  query: "signup",
+  itemType: "event",
+  maxResults: 5
+})
+
+Server ← {
+  "results": [
+    {
+      "rank": 1,
+      "name": "Account Created",
+      "itemType": "event",
+      "itemId": "evt-9f2b...",
+      "relevance": 0.91,
+      "description": "Sent when a new account is successfully created..."
+    },
+    {
+      "rank": 2,
+      "name": "Signup Started",
+      "itemType": "event",
+      "itemId": "evt-3c11...",
+      "relevance": 0.87,
+      "description": "Sent when the user opens the signup screen..."
+    }
+  ]
+}
+
+Claude → get({
+  type: "event",
+  id: "evt-9f2b...",
+  includePropertyDetails: true
+})
+
+Server ← {
+  "name": "Account Created",
+  "id": "evt-9f2b...",
+  "description": "Sent when a new account is successfully created.",
+  "sources": ["iOS", "Android", "Web"],
+  "properties": [
+    {
+      "name": "Authentication Method",
+      "type": "string",
+      "allowedValues": ["Email", "Google", "Apple"]
+    },
+    { "name": "Referral Source", "type": "string" }
+  ]
+}
+
+Claude: You have two signup events. The closest match is **Account Created**
+— sent when a user successfully creates an account — with properties
+Authentication Method (Email, Google, Apple) and Referral Source. There's
+also **Signup Started**, fired when the signup screen opens. Want a closer
+look at either?
+```
+
+### Create a property on a branch
+
+```text
+You: Add a Checkout Method property to the Checkout Completed event.
+
+Claude: I'll create a branch, add the property, and attach it to the event.
+You'll see a one-time re-auth prompt for write access in your browser.
+
+Claude → workflow({
+  action: "create_branch",
+  branchName: "add-checkout-method"
+})
+
+Server ← {
+  "branchId": "br-7d2f...",
+  "branchName": "add-checkout-method",
+  "branchUrl": "https://www.avo.app/schemas/default/branches/br-7d2f..."
+}
+
+Claude → get({ type: "event", name: "Checkout Completed" })
+
+Server ← {
+  "name": "Checkout Completed",
+  "id": "evt-c2a8...",
+  "description": "Sent when the user successfully completes a checkout."
+}
+
+Claude → save_items({
+  branchId: "br-7d2f...",
+  items: [
+    {
+      op: "create",
+      type: "property",
+      tempId: "checkout_method",
+      name: "Checkout Method",
+      propertyType: "string",
+      sendAs: "event",
+      description: "How the user completed checkout (Apple Pay, Google Pay, Card)"
+    },
+    {
+      op: "update",
+      type: "event",
+      eventId: "evt-c2a8...",
+      addProperties: ["$tmp:checkout_method"]
+    }
+  ]
+})
+
+Server ← {
+  "success": true,
+  "createdEntities": [
+    {
+      "name": "Checkout Method",
+      "entityId": "prop-44e1...",
+      "entityType": "property"
+    }
+  ],
+  "updatedEntities": [
+    {
+      "name": "Checkout Completed",
+      "entityId": "evt-c2a8...",
+      "entityType": "event"
+    }
+  ],
+  "removedEntities": [],
+  "errors": [],
+  "warnings": []
+}
+
+Claude: Done. **Checkout Method** (string, event property) is created and
+attached to **Checkout Completed** on the branch
+[`add-checkout-method`](https://www.avo.app/schemas/default/branches/br-7d2f...).
+Open the branch in the Avo app to review and merge to main — merging stays
+a human step.
+```
+
+### Open a new branch
+
+```text
+You: Open a new branch called update-signup-flow.
+
+Claude: You'll see a one-time re-auth prompt for write access in your browser.
+
+Claude → workflow({
+  action: "create_branch",
+  branchName: "update-signup-flow"
+})
+
+Server ← {
+  "branchId": "br-1a4c...",
+  "branchName": "update-signup-flow",
+  "branchUrl": "https://www.avo.app/schemas/default/branches/br-1a4c..."
+}
+
+Claude: Branch
+[`update-signup-flow`](https://www.avo.app/schemas/default/branches/br-1a4c...)
+is ready. What changes do you want to make on it?
+```
+
+## Troubleshooting
+
+**A second browser prompt appears the first time you write.** Write tools require the `write` scope, which is a step-up consent on top of `read`. Your client opens the OAuth flow again and the prompt only appears once per session.
+
+**`search` returns nothing for a clearly relevant query.** Semantic search requires Avo Intelligence Smart Search to be enabled. Workspace admins can turn it on in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). Without it, fall back to `get` with an exact name.
+
+**The wrong branch is returned by name.** `branchName` resolves to a best match and prioritizes open branches, so an ambiguous name can pick the wrong one. Resolve the name to a `branchId` with `list_branches` and pass `branchId` to the follow-up call.
+
+**`save_items` returns a `NotYetImplemented` error.** A small set of operations are not supported yet — removing events, removing event variants, and changing a property's `sendAs`. See the [`save_items` reference](/reference/avo-mcp/tools#save_items) for the full list.
+
+**Authentication never completes.** The first tool call opens a browser to sign in. MCP clients that cannot open a browser (CI runners, headless containers) cannot complete the OAuth flow.
+
+**`workspace access denied`.** The MCP enforces the same membership rules as the Avo web app. Confirm you're a member of the workspace at [avo.app](https://www.avo.app) — and that you're signing in with the same identity — before retrying.
+
+## Support and privacy
+
+For bug reports, feature requests, or help connecting an MCP client, email [support@avo.app](mailto:support@avo.app).
+
+How Avo collects, uses, and retains data is covered in the [Avo Privacy Policy](https://www.avo.app/l/privacy).
+
 ## Tools
 
 See the [Tools reference](/reference/avo-mcp/tools) for the full list of tools and their parameters.

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -18,19 +18,14 @@ The Avo MCP (Model Context Protocol) server exposes your Avo tracking plan to AI
 
 ## What you can do
 
-### Read (scope: `read`)
+- **Design tracking for a new feature** from a product brief — Claude reads your audit rules, finds reusable items, and proposes a plan before writing.
+- **Look up how an event is defined**, including its properties, sources, descriptions, and constraints.
+- **Find events, properties, or metrics by meaning** — a query like *"user signed up"* matches `Account Created` even when the exact name is unknown.
+- **Review the structured diff of an Avo branch** and pull per-source code snippets ready to drop into your codebase.
+- **Create a branch and add or update events, properties, and event variants** in a single batched write.
+- **Combine Avo with your data MCP** (Amplitude, Mixpanel, BigQuery, etc.) to diagnose tracking gaps from real data.
 
-- Browse branches and see who created, reviewed, or collaborated on them
-- Get implementation guides and code diffs for a specific source on a branch
-- Look up details for any tracking plan item — events, properties, metrics, categories, property bundles, sources, destinations, group types, event variants
-- Search the plan semantically by meaning
-- Discover available sources in your workspace
-
-### Write (scope: `write`)
-
-- Create a new branch from main
-- Create, update, and (for some entities) remove events, properties, and event variants on a branch
-- Cross-reference newly created items inside a single batch using temporary IDs
+The `read` scope covers everything except the last two; writes step up to a `write` scope on first use.
 
 ## Capability matrix
 
@@ -119,23 +114,14 @@ Call `list_workspaces` to find your `workspaceId`.
 
 Pass `workspaceId` to every workspace-scoped tool. (Stdio clients can also set the `WORKSPACE_ID` environment variable so it's picked up automatically.)
 
-## Example workflows
+## Example: search and save_items
 
-The connector's core flows, each with a concrete example. Tool calls are written inline as `tool(arguments)`; the JSON blocks show what success looks like. Real responses include the full item shape documented in the [Tools reference](/reference/avo-mcp/tools).
+The two tools a catalog reviewer is most likely to call. Real responses include the full item shape — see the [Tools reference](/reference/avo-mcp/tools) for the canonical schema.
 
-### Discover what's in the plan
-
-Use `search` for fuzzy lookup by meaning ("user signed up" matches `Account Created`), `get` for an exact name or ID, and structural-filter `search` (no `query`, just filter fields like `eventNames` or `properties`) to list items by relationship.
-
-<Callout type="info" emoji="🔒">
-  Semantic search requires Avo Intelligence Smart Search to be enabled in your workspace. Workspace admins can enable it in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). Without it, fall back to `get` with an exact name.
-</Callout>
-
-**You:** What events do we have for signup?
-
-Claude calls `search({ query: "signup", itemType: "event" })`. Returns:
+Look up signup-related events with semantic `search`:
 
 ```json
+// search({ query: "signup", itemType: "event" })
 {
   "results": [
     {
@@ -143,66 +129,31 @@ Claude calls `search({ query: "signup", itemType: "event" })`. Returns:
       "name": "Account Created",
       "itemId": "evt-9f2b...",
       "relevance": 0.91,
-      "description": "Sent when a new account is successfully created..."
+      "description": "Sent when a new account is successfully created."
     },
     {
       "rank": 2,
       "name": "Signup Started",
       "itemId": "evt-3c11...",
       "relevance": 0.87,
-      "description": "Sent when the user opens the signup screen..."
+      "description": "Sent when the user opens the signup screen."
     }
   ]
 }
 ```
 
-Claude then calls `get({ type: "event", id: "evt-9f2b...", includePropertyDetails: true })` for the full shape, and replies:
-
-**Claude:** You have two signup events. The closest match is **Account Created** — sent when a user successfully creates an account — with properties Authentication Method (Email, Google, Apple) and Referral Source. There's also **Signup Started**, fired when the signup screen opens. Want a closer look at either?
-
-### Design tracking for a new feature
-
-The flagship write flow. Claude reads the workspace's audit rules with `get(workspaceConfig)`, does both-lenses recon (semantic `search` and structural-filter `search`) to find what already exists, proposes a plan, and on approval creates a branch with `workflow` and writes the new items in a single batched `save_items` call — using `tempId` to attach a newly-created property to a newly-created event atomically.
-
-**You:** We're adding social sharing to the post detail screen — Twitter, LinkedIn, or copy link. Design the tracking for it.
-
-**Claude:** I'll check the workspace's audit rules, see what already exists, and propose a plan before touching a branch.
-
-Claude calls `get({ type: "workspaceConfig" })`, which returns the workspace's naming and audit rules:
+Create a new property and a new event in a single batched `save_items` call, using `tempId` to attach the new property to the new event atomically:
 
 ```json
-{
-  "eventNaming": {
-    "structure": "object-action",
-    "casing": "Title Case",
-    "tense": "past"
-  },
-  "rules": [
-    "Event names must end in a past-tense verb",
-    "Property names must be descriptive (e.g. Product Name, not Product)"
-  ]
-}
-```
-
-Claude then searches for existing share-related events with `search({ query: "share", itemType: "event" })`, and lists the properties on the matched `Article Shared` event with `search({ itemType: "property", eventNames: ["Article Shared"] })` — finding `Share Method` and `Share Destination` already exist.
-
-**Claude:** Here's the plan, anchored on a **Post Share Rate** metric:
-
-**Reuse**
-- `Share Method` (string: Twitter, LinkedIn, Copy Link) — already on `Article Shared`
-- `Share Destination` — same shape we need
-
-**Create**
-- **Post Shared** event — sent when a user shares a post from the post detail screen
-- **Post ID** property (string, event) — the ID of the post being shared
-
-Matches the workspace convention (Title Case, object-action, past tense). Proceed with the branch?
-
-**You:** yes
-
-Claude calls `workflow({ action: "create_branch", branchName: "add-post-sharing-tracking" })`, then batches the new property and the new event in one `save_items` call. The event's `properties` array references the new property by `"$tmp:post_id"` alongside the real IDs of the two reused properties — the server resolves the temp ID into a real one and attaches everything atomically. `save_items` returns:
-
-```json
+// save_items({
+//   branchId: "br-7d2f...",
+//   items: [
+//     { op: "create", type: "property", tempId: "post_id",
+//       name: "Post ID", propertyType: "string", sendAs: "event" },
+//     { op: "create", type: "event", name: "Post Shared",
+//       properties: ["$tmp:post_id"], sources: ["src-web"] }
+//   ]
+// })
 {
   "success": true,
   "createdEntities": [
@@ -216,79 +167,9 @@ Claude calls `workflow({ action: "create_branch", branchName: "add-post-sharing-
 }
 ```
 
-**Claude:** Done. Branch [`add-post-sharing-tracking`](https://www.avo.app/schemas/default/branches/br-4e8a...) has the new **Post Shared** event with one new property (**Post ID**) and two reused ones (**Share Method**, **Share Destination**). Open the branch in the Avo app to review and merge to main.
-
-### Review and implement a branch in code
-
-Resolve a branch by name with `list_branches`, read the high-level change set with `get_branch_implementation_guide`, then pull the per-event code diff for a specific source with `get_branch_code_snippets` (after looking up the `sourceId` via `get_sources`). Implementation handoff: the diff goes into the codebase, code review happens in git, and the human merges the Avo branch from the web app.
-
-**You:** I'm implementing the update-signup-flow branch on iOS. Walk me through it.
-
-Claude resolves the branch name with `list_branches({ branchName: "update-signup-flow" })`, then calls `get_branch_implementation_guide({ branchId: "br-6c2d..." })`:
-
-```json
-{
-  "summary": { "newEvents": 1, "modifiedEvents": 1, "deletedEvents": 0 },
-  "newEvents": [
-    {
-      "name": "Signup Step Completed",
-      "description": "Sent when the user completes a step in the signup funnel.",
-      "properties": ["Signup Step", "Step Outcome"],
-      "implementationType": "Codegen"
-    }
-  ],
-  "modifiedEvents": [
-    {
-      "name": "Signup Completed",
-      "changes": [
-        { "field": "properties", "added": ["Authentication Method"] }
-      ],
-      "implementationType": "Codegen"
-    }
-  ]
-}
-```
-
-Claude looks up the iOS source with `get_sources()`, then pulls per-event code diffs with `get_branch_code_snippets({ branchId: "br-6c2d...", sourceId: "src-ios" })`:
-
-```json
-{
-  "snippets": [
-    {
-      "event": "Signup Step Completed",
-      "status": "New",
-      "label": "Codegen",
-      "diff": "+ Avo.signupStepCompleted(signupStep: ..., stepOutcome: ...)"
-    },
-    {
-      "event": "Signup Completed",
-      "status": "Updated",
-      "label": "Codegen",
-      "diff": "- Avo.signupCompleted()\n+ Avo.signupCompleted(authenticationMethod: ...)"
-    }
-  ]
-}
-```
-
-**Claude:** Here's what's on `update-signup-flow` for iOS:
-
-**1 new event** — `Signup Step Completed` (Codegen)
-**1 modified event** — `Signup Completed` gains an `Authentication Method` property (Codegen)
-
-The iOS source uses Avo Codegen, so the next step is to run `avo pull` locally to regenerate `Avo.swift`, then update each call site:
-
-- Add `Avo.signupStepCompleted(...)` at each signup-step transition
-- Pass `authenticationMethod` to existing `Avo.signupCompleted()` calls
-
-Want me to find the call sites in the iOS project, or are you good from here?
-
----
-
-This isn't a finite list of workflows — check out the [Tools reference](/reference/avo-mcp/tools) to explore what else is possible.
-
 ## Tools
 
-See the [Tools reference](/reference/avo-mcp/tools) for the full list of tools and their parameters.
+See the [Tools reference](/reference/avo-mcp/tools) for the full list of tools, parameter shapes, and response schemas.
 
 ## Troubleshooting
 

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -25,8 +25,6 @@ The Avo MCP (Model Context Protocol) server exposes your Avo tracking plan to AI
 - **Create a branch and add or update events, properties, and event variants** in a single batched write.
 - **Combine Avo with your data MCP** (Amplitude, Mixpanel, BigQuery, etc.) to diagnose tracking gaps from real data.
 
-The `read` scope covers everything except the last two; writes step up to a `write` scope on first use.
-
 ## Capability matrix
 
 | Capability | Tool | Scope |
@@ -113,59 +111,6 @@ Call `list_workspaces` to find your `workspaceId`.
 **2. Use any tool**
 
 Pass `workspaceId` to every workspace-scoped tool. (Stdio clients can also set the `WORKSPACE_ID` environment variable so it's picked up automatically.)
-
-## Example: search and save_items
-
-The two tools a catalog reviewer is most likely to call. Real responses include the full item shape — see the [Tools reference](/reference/avo-mcp/tools) for the canonical schema.
-
-Look up signup-related events with semantic `search`:
-
-```json
-// search({ query: "signup", itemType: "event" })
-{
-  "results": [
-    {
-      "rank": 1,
-      "name": "Account Created",
-      "itemId": "evt-9f2b...",
-      "relevance": 0.91,
-      "description": "Sent when a new account is successfully created."
-    },
-    {
-      "rank": 2,
-      "name": "Signup Started",
-      "itemId": "evt-3c11...",
-      "relevance": 0.87,
-      "description": "Sent when the user opens the signup screen."
-    }
-  ]
-}
-```
-
-Create a new property and a new event in a single batched `save_items` call, using `tempId` to attach the new property to the new event atomically:
-
-```json
-// save_items({
-//   branchId: "br-7d2f...",
-//   items: [
-//     { op: "create", type: "property", tempId: "post_id",
-//       name: "Post ID", propertyType: "string", sendAs: "event" },
-//     { op: "create", type: "event", name: "Post Shared",
-//       properties: ["$tmp:post_id"], sources: ["src-web"] }
-//   ]
-// })
-{
-  "success": true,
-  "createdEntities": [
-    { "name": "Post ID", "entityId": "prop-9d44...", "entityType": "property" },
-    { "name": "Post Shared", "entityId": "evt-3f01...", "entityType": "event" }
-  ],
-  "updatedEntities": [],
-  "removedEntities": [],
-  "errors": [],
-  "warnings": []
-}
-```
 
 ## Tools
 

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -238,6 +238,29 @@ Semantic similarity search across events, properties, metrics, categories, and p
 
 **Returns:** Ranked results with rank, name, type, item ID, relevance percentage, and a truncated description (80 characters).
 
+```json
+{
+  "results": [
+    {
+      "rank": 1,
+      "name": "Account Created",
+      "itemType": "event",
+      "itemId": "evt-9f2b...",
+      "relevance": 0.91,
+      "description": "Sent when a new account is successfully created."
+    },
+    {
+      "rank": 2,
+      "name": "Signup Started",
+      "itemType": "event",
+      "itemId": "evt-3c11...",
+      "relevance": 0.87,
+      "description": "Sent when the user opens the signup screen."
+    }
+  ]
+}
+```
+
 Search is performed against the **main branch** only. There is a brief indexing lag for very recently created or updated items.
 
 <Callout type="info" emoji="🔒">
@@ -436,6 +459,21 @@ Returns a structured result with:
 - `errors` — per-item validation or audit errors, each with the item index, name, and a message.
 - `warnings` — non-fatal notices, same shape as errors.
 - `success` — overall boolean.
+
+```json
+{
+  "success": true,
+  "createdEntities": [
+    { "name": "Checkout Method", "entityId": "prop-9d44...", "entityType": "property" }
+  ],
+  "updatedEntities": [
+    { "name": "Checkout Completed", "entityId": "evt-3f01...", "entityType": "event" }
+  ],
+  "removedEntities": [],
+  "errors": [],
+  "warnings": []
+}
+```
 
 **Common errors:**
 


### PR DESCRIPTION
## Summary

- Adds three "Example session" blocks to `pages/reference/avo-mcp/overview.mdx` — find events by meaning, create a property on a branch, open a new branch — with the user prompt, the tool calls Claude makes, and sample JSON responses. Sample responses cover `search`, `get`, `workflow`, and `save_items` so reviewers can see what success looks like.
- Adds a **Troubleshooting** section covering the six most common failure modes (write scope step-up, Smart Search off, ambiguous `branchName`, `NotYetImplemented`, headless OAuth, workspace access).
- Adds a **Support and privacy** section with a direct support contact and a link to the Avo Privacy Policy.

Together these close the gaps against the [Anthropic Software Directory Policy](https://support.claude.com/en/articles/13145358-anthropic-software-directory-policy) §3.A (privacy link), §3.B (support channel), §3.C (troubleshooting), and §3.E (three working example use cases).

Closes [AVO-2879](https://linear.app/avo/issue/AVO-2879/polish-mcp-docs-page-with-example-dialogue-sample-responses).

## Test plan

- [ ] Render the docs site locally and confirm the new sections render with correct headings and the fenced code blocks display cleanly
- [ ] Verify all internal anchor links resolve (`/reference/avo-mcp/tools#save_items`, `/reference/avo-mcp/tools`, Workspace Settings link)
- [ ] Verify the external Privacy Policy link works (`https://www.avo.app/l/privacy`)
- [ ] Sanity-check the sample JSON shapes against the actual server responses (`search`, `get`, `workflow`, `save_items`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added "Example sessions" with detailed end-to-end workflow examples demonstrating event search and retrieval, branch creation with property management, and branch operations.
* Added "Troubleshooting" section addressing common issues related to MCP integration, authentication, search functionality, and write operations.
* Added "Support and privacy" section providing contact information for support and privacy policy reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avohq/docs/pull/1706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->