### PR TITLE
Polish Avo MCP docs for Claude AI catalog submission

### DIFF
--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -132,7 +132,7 @@ See the [Tools reference](/reference/avo-mcp/tools) for the full list of tools, 
 
 **The wrong branch is returned by name.** `branchName` resolves to a best match and prioritizes open branches, so an ambiguous name can pick the wrong one. Resolve the name to a `branchId` with `list_branches` first and pass `branchId` to the follow-up call.
 
-**`save_items` returns a `NotYetImplemented` error.** A small set of operations are not supported yet — archiving events, removing event variants, and changing a property's `sendAs`. See the [`save_items` reference](/reference/avo-mcp/tools#save_items) for the full list.
+**`save_items` returns a `NotYetImplemented` error.** A small set of operations are not supported yet — removing event variants and changing a property's `sendAs`. See the [`save_items` reference](/reference/avo-mcp/tools#save_items) for the full list.
 
 **Authentication never completes.** The first tool call opens a browser to sign in. MCP clients that cannot open a browser (CI runners, headless containers) cannot complete the OAuth flow.
 

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -132,13 +132,9 @@ See the [Tools reference](/reference/avo-mcp/tools) for the full list of tools, 
 
 ## Troubleshooting
 
+Authentication and workspace access issues live here. For tool-specific issues — `search` returning nothing, ambiguous branch names, `NotYetImplemented` errors — see [Troubleshooting in the Tools reference](/reference/avo-mcp/tools#troubleshooting).
+
 **A second browser prompt appears the first time you write.** Write tools require the `write` scope, which is a step-up consent on top of `read`. Your client opens the OAuth flow again; the prompt appears once per session.
-
-**`search` returns nothing for a clearly relevant query.** Semantic search requires Avo Intelligence Smart Search to be enabled. Workspace admins can turn it on in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). Without it, fall back to `get` with an exact name.
-
-**The wrong branch is returned by name.** `branchName` resolves to a best match and prioritizes open branches, so an ambiguous name can pick the wrong one. Resolve the name to a `branchId` with `list_branches` first and pass `branchId` to the follow-up call.
-
-**`save_items` returns a `NotYetImplemented` error.** A small set of operations are not supported yet — removing event variants and changing a property's `sendAs`. See the [`save_items` reference](/reference/avo-mcp/tools#save_items) for the full list.
 
 **Authentication never completes.** The first tool call opens a browser to sign in. MCP clients that cannot open a browser (CI runners, headless containers) cannot complete the OAuth flow.
 

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -7,7 +7,7 @@ import { Callout } from 'nextra/components'
 
 # Avo MCP
 
-The Avo MCP (Model Context Protocol) server exposes your Avo tracking plan to AI coding assistants. Tools like Claude, ChatGPT, Cursor, Codex, Claude Code, and other MCP-compatible clients can **read** your tracking plan, **explore branches**, and **write changes on a branch** — without you copy-pasting specs into the chat.
+Avo MCP gives AI coding assistants direct access to your Avo tracking plan. Claude, ChatGPT, Cursor, Codex, Claude Code, and other MCP-compatible clients can **read** the plan, **explore branches**, and **write changes on a branch** — without copy-pasting specs into the chat. (MCP stands for [Model Context Protocol](https://modelcontextprotocol.io/).)
 
 - **Transport:** Streamable HTTP at `https://mcp.avo.app/mcp`
 - **Authentication:** OAuth 2.0 + PKCE, scoped to your Avo identity
@@ -22,8 +22,6 @@ The Avo MCP (Model Context Protocol) server exposes your Avo tracking plan to AI
 </Callout>
 
 ## Use cases
-
-The Avo MCP lets Claude work directly against your tracking plan — reading items, designing changes against your workspace's conventions, and writing those changes back to a branch.
 
 **Getting started.** Every tool except `list_workspaces` is workspace-scoped. Call `list_workspaces` first to find your `workspaceId`, then pass that ID to subsequent tool calls. (Stdio clients can also set the `WORKSPACE_ID` environment variable so it's picked up automatically.)
 
@@ -71,6 +69,10 @@ Branch read flows are covered by `get` and `search`. One transitional tool — [
 
 ## Setup
 
+<Callout type="info" emoji="🔒">
+  **First-call behavior.** Your client must support HTTP transport and the browser-based OAuth 2.0 authorization flow. The first tool invocation opens a browser, you sign in with Avo, the client caches the token, and subsequent calls use it automatically. CI runners and headless containers cannot complete this flow.
+</Callout>
+
 ### Claude Code (CLI)
 
 ```bash
@@ -112,8 +114,6 @@ Add the following to your `mcp.json` (or `~/.cursor/mcp.json` for global config)
   }
 }
 ```
-
-Your client must support HTTP transport and the browser-based OAuth authorization flow. The first tool invocation opens a browser, you sign in with your Avo credentials, the client receives a token, and the token is cached for subsequent calls. Clients that cannot complete the OAuth flow will not work with the Avo MCP.
 
 ## Authentication
 

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -126,10 +126,6 @@ The MCP server uses OAuth 2.0 with PKCE.
 
 If a tool that requires `write` is called with a token that only has `read`, the server returns an error prompting the client to re-authorize with `write`.
 
-## Tools
-
-See the [Tools reference](/reference/avo-mcp/tools) for the full list of tools, parameter shapes, and response schemas.
-
 ## Troubleshooting
 
 Authentication and workspace access issues live here. For tool-specific issues — `search` returning nothing, ambiguous branch names, `NotYetImplemented` errors — see [Troubleshooting in the Tools reference](/reference/avo-mcp/tools#troubleshooting).

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -1,3 +1,8 @@
+---
+title: Avo MCP
+description: Connect Claude, ChatGPT, Cursor, and other MCP-compatible clients to your Avo tracking plan. Read tracking-plan items, design changes from a feature brief, and write changes back to a branch via OAuth 2.0.
+---
+
 import { Callout } from 'nextra/components'
 
 # Avo MCP
@@ -16,13 +21,13 @@ The Avo MCP (Model Context Protocol) server exposes your Avo tracking plan to AI
   Writes require the `write` scope and always happen on a branch. The MCP server will never merge a branch into main — that remains a human step in the [Avo web app](https://www.avo.app).
 </Callout>
 
-## What you can do
+## Use cases
 
 The Avo MCP lets Claude work directly against your tracking plan — reading items, designing changes against your workspace's conventions, and writing those changes back to a branch.
 
 **Getting started.** Every tool except `list_workspaces` is workspace-scoped. Call `list_workspaces` first to find your `workspaceId`, then pass that ID to subsequent tool calls. (Stdio clients can also set the `WORKSPACE_ID` environment variable so it's picked up automatically.)
 
-These are the three major use cases — many more flows are possible through the same tools.
+The three use cases below cover the most common flows. Many more are possible through the same tools.
 
 ### Search the tracking plan
 
@@ -56,6 +61,13 @@ The MCP exposes five tools mapped to agent intents:
 | **Progress** — create a branch or update its description | [`workflow`](/reference/avo-mcp/tools#workflow) | `write` |
 
 Branch read flows are covered by `get` and `search`. One transitional tool — [`list_branches`](/reference/avo-mcp/tools#list_branches) — remains available while its replacement in `search(type:"branch")` ships. See the [Tools reference](/reference/avo-mcp/tools) for full parameters, return shapes, and examples per tool.
+
+## Limits
+
+- **`save_items`** accepts at most 100 items per call.
+- **`search`** semantic mode caps at 20 results per call (default 10). Filter mode caps at 500 results (default 10).
+- **`list_branches`** returns up to 50 results per page (default 25). Use `pageToken` to paginate.
+- **Tokens** carry the user's identity; workspace access is verified at every call against your Avo workspace membership, so a token alone is not sufficient if you lose workspace access.
 
 ## Setup
 
@@ -132,8 +144,37 @@ See the [Tools reference](/reference/avo-mcp/tools) for the full list of tools, 
 
 **`workspace access denied`.** The MCP enforces the same membership rules as the Avo web app. Confirm you're a member of the workspace at [avo.app](https://www.avo.app) — and that you're signing in with the same identity — before retrying.
 
+## FAQ
+
+### Does the Avo MCP merge branches to main?
+
+No. The MCP creates branches and writes items on them, but merging always remains a human step in the [Avo web app](https://www.avo.app). Merges to main are deliberate, reviewable changes to your tracking plan, not background automation.
+
+### What data does Avo collect through the MCP?
+
+The MCP reads and writes tracking-plan content (events, properties, metrics, etc.) already stored in your Avo workspace. It does not collect your codebase, your prompts, or any data your MCP client sends to its model. Standard operational telemetry — request IDs, error counts — is retained for reliability. See the [Avo Privacy Policy](https://www.avo.app/l/privacy) for full details.
+
+### Do I need to be a workspace admin to use the Avo MCP?
+
+For most tools, no — any workspace member can read the plan and write to branches via the MCP. Two exceptions: enabling semantic `search` requires an admin to turn on Avo Intelligence Smart Search in [Workspace Settings](https://www.avo.app/schemas/default?settings=general), and adding the connector inside Claude Desktop requires admin permissions in your Claude organization.
+
+### Can multiple team members use the Avo MCP simultaneously?
+
+Yes. Each user authenticates with their own Avo identity via OAuth, so concurrent sessions and writes are independent and audited per user in the Avo web app.
+
+### Which MCP clients are supported?
+
+Any client that supports HTTP transport and the browser-based OAuth 2.0 authorization flow. Tested clients include Claude Code, Claude Desktop, Cursor, and Codex. Clients that cannot open a browser — CI runners, headless containers — cannot complete the OAuth flow.
+
 ## Support and privacy
 
 For bug reports, feature requests, or help connecting an MCP client, email [support@avo.app](mailto:support@avo.app).
 
-How Avo collects, uses, and retains data is covered in the [Avo Privacy Policy](https://www.avo.app/l/privacy).
+### Privacy summary
+
+- **What is collected.** The MCP reads and writes tracking-plan content already stored in your Avo workspace. It does not collect your codebase, prompts, or data your MCP client sends to its model.
+- **How it's used.** Tool calls update your tracking plan or return its current state. Operational telemetry (request IDs, error counts) is collected for reliability and abuse prevention.
+- **Storage and retention.** Tracking-plan content lives in your Avo workspace under the existing retention policy. OAuth tokens and operational logs follow the schedule in the [Avo Privacy Policy](https://www.avo.app/l/privacy).
+- **Third-party sharing.** Avo does not forward tracking-plan content to AI providers. The MCP returns data to your client; your client decides what to send onward to its model.
+
+Full data-handling details are in the [Avo Privacy Policy](https://www.avo.app/l/privacy).

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -18,6 +18,12 @@ The Avo MCP (Model Context Protocol) server exposes your Avo tracking plan to AI
 
 ## What you can do
 
+The Avo MCP lets Claude work directly against your tracking plan — reading items, designing changes against your workspace's conventions, and writing those changes back to a branch.
+
+**Getting started.** Every tool except `list_workspaces` is workspace-scoped. Call `list_workspaces` first to find your `workspaceId`, then pass that ID to subsequent tool calls. (Stdio clients can also set the `WORKSPACE_ID` environment variable so it's picked up automatically.)
+
+These are the three major use cases — many more flows are possible through the same tools.
+
 ### Search the tracking plan
 
 Ask Claude what's already instrumented — *"what events do we have for signup?"* or *"is there anything that captures checkout completion?"*. The MCP runs a semantic search across events, properties, and metrics, returns ranked matches, then pulls the full definition of the ones that look right.
@@ -107,18 +113,6 @@ The MCP server uses OAuth 2.0 with PKCE.
 - **Token signing:** RS256 keys backed by Google Cloud KMS (HSM) in production.
 
 If a tool that requires `write` is called with a token that only has `read`, the server returns an error prompting the client to re-authorize with `write`.
-
-## Getting started
-
-Every tool except `list_workspaces` is workspace-scoped. The typical first-use sequence:
-
-**1. Discover your workspaces**
-
-Call `list_workspaces` to find your `workspaceId`.
-
-**2. Use any tool**
-
-Pass `workspaceId` to every workspace-scoped tool. (Stdio clients can also set the `WORKSPACE_ID` environment variable so it's picked up automatically.)
 
 ## Tools
 

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -67,6 +67,28 @@ Branch read flows are covered by `get` and `search`. One transitional tool — [
 - **`list_branches`** returns up to 50 results per page (default 25). Use `pageToken` to paginate.
 - **Tokens** carry the user's identity; workspace access is verified at every call against your Avo workspace membership, so a token alone is not sufficient if you lose workspace access.
 
+## FAQ
+
+### Does the Avo MCP merge branches to main?
+
+No. The MCP creates branches and writes items on them, but merging always remains a human step in the [Avo web app](https://www.avo.app). Merges to main are deliberate, reviewable changes to your tracking plan, not background automation.
+
+### What data does Avo collect through the MCP?
+
+The MCP reads and writes tracking-plan content (events, properties, metrics, etc.) already stored in your Avo workspace. It does not collect your codebase, your prompts, or any data your MCP client sends to its model. Standard operational telemetry — request IDs, error counts — is retained for reliability. See the [Avo Privacy Policy](https://www.avo.app/l/privacy) for full details.
+
+### Do I need to be a workspace admin to use the Avo MCP?
+
+For most tools, no — any workspace member can read the plan and write to branches via the MCP. Two exceptions: enabling semantic `search` requires an admin to turn on Avo Intelligence Smart Search in [Workspace Settings](https://www.avo.app/schemas/default?settings=general), and adding the connector inside Claude Desktop requires admin permissions in your Claude organization.
+
+### Can multiple team members use the Avo MCP simultaneously?
+
+Yes. Each user authenticates with their own Avo identity via OAuth, so concurrent sessions and writes are independent and audited per user in the Avo web app.
+
+### Which MCP clients are supported?
+
+Any client that supports HTTP transport and the browser-based OAuth 2.0 authorization flow. Tested clients include Claude Code, Claude Desktop, Cursor, and Codex. Clients that cannot open a browser — CI runners, headless containers — cannot complete the OAuth flow.
+
 ## Setup
 
 <Callout type="info" emoji="🔒">
@@ -135,28 +157,6 @@ Authentication and workspace access issues live here. For tool-specific issues �
 **Authentication never completes.** The first tool call opens a browser to sign in. MCP clients that cannot open a browser (CI runners, headless containers) cannot complete the OAuth flow.
 
 **`workspace access denied`.** The MCP enforces the same membership rules as the Avo web app. Confirm you're a member of the workspace at [avo.app](https://www.avo.app) — and that you're signing in with the same identity — before retrying.
-
-## FAQ
-
-### Does the Avo MCP merge branches to main?
-
-No. The MCP creates branches and writes items on them, but merging always remains a human step in the [Avo web app](https://www.avo.app). Merges to main are deliberate, reviewable changes to your tracking plan, not background automation.
-
-### What data does Avo collect through the MCP?
-
-The MCP reads and writes tracking-plan content (events, properties, metrics, etc.) already stored in your Avo workspace. It does not collect your codebase, your prompts, or any data your MCP client sends to its model. Standard operational telemetry — request IDs, error counts — is retained for reliability. See the [Avo Privacy Policy](https://www.avo.app/l/privacy) for full details.
-
-### Do I need to be a workspace admin to use the Avo MCP?
-
-For most tools, no — any workspace member can read the plan and write to branches via the MCP. Two exceptions: enabling semantic `search` requires an admin to turn on Avo Intelligence Smart Search in [Workspace Settings](https://www.avo.app/schemas/default?settings=general), and adding the connector inside Claude Desktop requires admin permissions in your Claude organization.
-
-### Can multiple team members use the Avo MCP simultaneously?
-
-Yes. Each user authenticates with their own Avo identity via OAuth, so concurrent sessions and writes are independent and audited per user in the Avo web app.
-
-### Which MCP clients are supported?
-
-Any client that supports HTTP transport and the browser-based OAuth 2.0 authorization flow. Tested clients include Claude Code, Claude Desktop, Cursor, and Codex. Clients that cannot open a browser — CI runners, headless containers — cannot complete the OAuth flow.
 
 ## Support and privacy
 

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -75,7 +75,7 @@ No. The MCP creates branches and writes items on them, but merging always remain
 
 ### What data does Avo collect through the MCP?
 
-The MCP reads and writes tracking-plan content (events, properties, metrics, etc.) already stored in your Avo workspace. It does not collect your codebase, your prompts, or any data your MCP client sends to its model. Standard operational telemetry — request IDs, error counts — is retained for reliability. See the [Avo Privacy Policy](https://www.avo.app/l/privacy) for full details.
+The MCP reads and writes tracking-plan content — events, properties, event variants, metrics, categories, and property bundles — already stored in your Avo workspace. It does not collect your codebase, your prompts, or any data your MCP client sends to its model. Standard operational telemetry — request IDs, error counts — is retained for reliability. See the [Avo Privacy Policy](https://www.avo.app/l/privacy) for full details.
 
 ### Do I need to be a workspace admin to use the Avo MCP?
 

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -39,7 +39,7 @@ Share a PRD, Figma designs, or just a feature description. Claude reads your wor
 
 Point Claude at a branch and it returns a structured diff: new, modified, and removed events with their properties and descriptions. Pick a source and ask for per-event code snippets to drop into your codebase. The diff is exact for [Avo Codegen](/implementation/avo-codegen-overview) sources and illustrative pseudocode for manually-instrumented sources.
 
-You can also:
+### Other use cases
 
 - Look up any event, property, or metric by exact name or ID
 - Combine Avo with your data MCP (Amplitude, Mixpanel, BigQuery, etc.) to diagnose tracking gaps from real data

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -40,7 +40,8 @@ Point Claude at a branch and it returns a structured diff: new, modified, and re
 ### Other example flows
 
 - Look up any event, property, or metric by exact name or ID
-- Combine Avo with your data MCP (Amplitude, Mixpanel, BigQuery, etc.) to diagnose tracking gaps from real data
+- Query your product data correctly through your data MCP (Amplitude, Mixpanel, BigQuery, etc.) — Avo knows your metric definitions and which events compose them, so AI agents can build accurate queries instead of guessing
+- Diagnose tracking gaps by comparing what your data MCP returns against Avo's plan
 - Make small edits to a branch — fill in allowed values, rename properties, add categories
 - Browse and filter open branches by status, creator, or reviewer
 

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -62,7 +62,7 @@ Branch read flows are covered by `get` and `search`. One transitional tool — [
 
 ## Limits
 
-- **`save_items`** accepts at most 100 items per call.
+- **`save_items`** accepts at most 50 items per call.
 - **`search`** semantic mode caps at 20 results per call (default 10). Filter mode caps at 500 results (default 10).
 - **`list_branches`** returns up to 50 results per page (default 25). Use `pageToken` to paginate.
 - **Tokens** carry the user's identity; workspace access is verified at every call against your Avo workspace membership, so a token alone is not sufficient if you lose workspace access.

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -39,7 +39,7 @@ Share a PRD, Figma designs, or just a feature description. Claude reads your wor
 
 Point Claude at a branch and it returns a structured diff: new, modified, and removed events with their properties and descriptions. Pick a source and ask for per-event code snippets to drop into your codebase. The diff is exact for [Avo Codegen](/implementation/avo-codegen-overview) sources and illustrative pseudocode for manually-instrumented sources.
 
-### Other use cases
+### Other example flows
 
 - Look up any event, property, or metric by exact name or ID
 - Combine Avo with your data MCP (Amplitude, Mixpanel, BigQuery, etc.) to diagnose tracking gaps from real data

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -18,37 +18,38 @@ The Avo MCP (Model Context Protocol) server exposes your Avo tracking plan to AI
 
 ## What you can do
 
-### Read (scope: `read`)
+### Search the tracking plan
 
-- Browse branches and see who created, reviewed, or collaborated on them
-- Get implementation guides and code diffs for a specific source on a branch
-- Look up details for any tracking plan item — events, properties, metrics, categories, property bundles, sources, destinations, group types, event variants
-- Search the plan semantically by meaning
-- Discover available sources in your workspace
+Ask Claude what's already instrumented — *"what events do we have for signup?"* or *"is there anything that captures checkout completion?"*. The MCP runs a semantic search across events, properties, and metrics, returns ranked matches, then pulls the full definition of the ones that look right.
 
-### Write (scope: `write`)
+### Design tracking for a new feature
 
-- Create a new branch from main
-- Create, update, and (for some entities) remove events, properties, and event variants on a branch
-- Cross-reference newly created items inside a single batch using temporary IDs
+Share a PRD, Figma designs, or just a feature description. Claude reads your workspace's audit rules, hunts for items you can reuse, and proposes a plan — events, properties, metrics — for you to review before any write happens. On approval, it creates a branch and writes everything in a single batched call, using temporary IDs to attach a brand-new property to a brand-new event in the same write. The MCP never merges to main — you finalize the branch in the Avo web app.
+
+### Review and implement an Avo branch
+
+Point Claude at a branch and it returns a structured diff: new, modified, and removed events with their properties and descriptions. Pick a source and ask for per-event code snippets to drop into your codebase. The diff is exact for [Avo Codegen](/implementation/avo-codegen-overview) sources and illustrative pseudocode for manually-instrumented sources.
+
+You can also:
+
+- Look up any event, property, or metric by exact name or ID
+- Combine Avo with your data MCP (Amplitude, Mixpanel, BigQuery, etc.) to diagnose tracking gaps from real data
+- Make small edits to a branch — fill in allowed values, rename properties, add categories
+- Browse and filter open branches by status, creator, or reviewer
 
 ## Capability matrix
 
-| Capability | Tool | Scope |
-|---|---|---|
-| Health check | [`health_check`](/reference/avo-mcp/tools#health_check) | `read` |
-| List workspaces you can access | [`list_workspaces`](/reference/avo-mcp/tools#list_workspaces) | `read` |
-| List branches in a workspace | [`list_branches`](/reference/avo-mcp/tools#list_branches) | `read` |
-| Branch details (reviewers, status, impacted sources) | [`get_branch_details`](/reference/avo-mcp/tools#get_branch_details) | `read` |
-| What changed on a branch (implementation guide) | [`get_branch_implementation_guide`](/reference/avo-mcp/tools#get_branch_implementation_guide) | `read` |
-| Per-event code diffs for a branch + source | [`get_branch_code_snippets`](/reference/avo-mcp/tools#get_branch_code_snippets) | `read` |
-| List sources in a workspace | [`get_sources`](/reference/avo-mcp/tools#get_sources) | `read` |
-| Look up any item by ID or exact name | [`get`](/reference/avo-mcp/tools#get) | `read` |
-| Semantic search across the plan | [`search`](/reference/avo-mcp/tools#search) | `read` |
-| Create a branch | [`workflow`](/reference/avo-mcp/tools#workflow) | `write` |
-| Create / update / remove events, properties, event variants on a branch | [`save_items`](/reference/avo-mcp/tools#save_items) | `write` |
+The MCP exposes five tools mapped to agent intents:
 
-See the [Tools reference](/reference/avo-mcp/tools) for full parameters, return shapes, and examples per tool.
+| Intent | Tool | Scope |
+|---|---|---|
+| **Entry point** — find your workspace IDs | [`list_workspaces`](/reference/avo-mcp/tools#list_workspaces) | `read` |
+| **Discover** — find items by meaning or by structural filter | [`search`](/reference/avo-mcp/tools#search) | `read` |
+| **Understand** — full details for an event, property, branch, source, etc. | [`get`](/reference/avo-mcp/tools#get) | `read` |
+| **Change** — create, update, remove, or archive items on a branch | [`save_items`](/reference/avo-mcp/tools#save_items) | `write` |
+| **Progress** — create a branch or update its description | [`workflow`](/reference/avo-mcp/tools#workflow) | `write` |
+
+Branch read flows are covered by `get` and `search`. One transitional tool — [`list_branches`](/reference/avo-mcp/tools#list_branches) — remains available while its replacement in `search(type:"branch")` ships. See the [Tools reference](/reference/avo-mcp/tools) for full parameters, return shapes, and examples per tool.
 
 ## Setup
 
@@ -109,7 +110,7 @@ If a tool that requires `write` is called with a token that only has `read`, the
 
 ## Getting started
 
-Most tools are workspace-scoped (`health_check` and `list_workspaces` are the exceptions). The typical first-use sequence:
+Every tool except `list_workspaces` is workspace-scoped. The typical first-use sequence:
 
 **1. Discover your workspaces**
 
@@ -119,34 +120,26 @@ Call `list_workspaces` to find your `workspaceId`.
 
 Pass `workspaceId` to every workspace-scoped tool. (Stdio clients can also set the `WORKSPACE_ID` environment variable so it's picked up automatically.)
 
-## Recommended agent flows
-
-### Explore the plan
-
-`list_workspaces` → `search` or `get` to inspect items by meaning or by ID/name.
-
-### Find work on a branch
-
-`list_branches` → `get_branch_details` → `get_branch_implementation_guide` → `get_branch_code_snippets` (with a `sourceId` from `get_sources`).
-
-### Add events for a new feature
-
-1. `workflow` with `action: "create_branch"` and a `branchName` → returns `branchId`.
-2. `save_items` on that `branchId` with a batch of `event` / `property` / `event_variant` items. Use `tempId` for forward references so a newly created property can be attached to a newly created event in a single call.
-3. Tell the user the branch is ready — the MCP does not merge. Open the branch in the [Avo web app](https://www.avo.app) (or ask a reviewer) to review and merge it to main.
-
-### Fix a property on an existing branch
-
-`list_branches` → `get_branch_details` to get `branchId` → `save_items` with `op: "update"` targeting an `eventId` or `propertyId`.
-
-### Searching for an event
-
-Use `search` to find events by meaning, not just exact name. A query like `"user signed up"` will match events named `Account Created` or `Registration Completed`.
-
-<Callout type="info" emoji="🔒">
-  Semantic search requires Avo Intelligence Smart Search to be enabled in your workspace. Workspace admins can enable it in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). If you don't have admin access, ask a workspace admin to enable it.
-</Callout>
-
 ## Tools
 
-See the [Tools reference](/reference/avo-mcp/tools) for the full list of tools and their parameters.
+See the [Tools reference](/reference/avo-mcp/tools) for the full list of tools, parameter shapes, and response schemas.
+
+## Troubleshooting
+
+**A second browser prompt appears the first time you write.** Write tools require the `write` scope, which is a step-up consent on top of `read`. Your client opens the OAuth flow again; the prompt appears once per session.
+
+**`search` returns nothing for a clearly relevant query.** Semantic search requires Avo Intelligence Smart Search to be enabled. Workspace admins can turn it on in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). Without it, fall back to `get` with an exact name.
+
+**The wrong branch is returned by name.** `branchName` resolves to a best match and prioritizes open branches, so an ambiguous name can pick the wrong one. Resolve the name to a `branchId` with `list_branches` first and pass `branchId` to the follow-up call.
+
+**`save_items` returns a `NotYetImplemented` error.** A small set of operations are not supported yet — archiving events, removing event variants, and changing a property's `sendAs`. See the [`save_items` reference](/reference/avo-mcp/tools#save_items) for the full list.
+
+**Authentication never completes.** The first tool call opens a browser to sign in. MCP clients that cannot open a browser (CI runners, headless containers) cannot complete the OAuth flow.
+
+**`workspace access denied`.** The MCP enforces the same membership rules as the Avo web app. Confirm you're a member of the workspace at [avo.app](https://www.avo.app) — and that you're signing in with the same identity — before retrying.
+
+## Support and privacy
+
+For bug reports, feature requests, or help connecting an MCP client, email [support@avo.app](mailto:support@avo.app).
+
+How Avo collects, uses, and retains data is covered in the [Avo Privacy Policy](https://www.avo.app/l/privacy).

--- a/pages/reference/avo-mcp/overview.mdx
+++ b/pages/reference/avo-mcp/overview.mdx
@@ -1,13 +1,13 @@
 ---
 title: Avo MCP
-description: Connect Claude, ChatGPT, Cursor, and other MCP-compatible clients to your Avo tracking plan. Read tracking-plan items, design changes from a feature brief, and write changes back to a branch via OAuth 2.0.
+description: Connect Claude, ChatGPT, Cursor, and other Model Context Protocol clients to your Avo tracking plan. Read tracking-plan items, design changes from a feature brief, and write changes back to a branch via OAuth 2.0.
 ---
 
 import { Callout } from 'nextra/components'
 
 # Avo MCP
 
-Avo MCP gives AI coding assistants direct access to your Avo tracking plan. Claude, ChatGPT, Cursor, Codex, Claude Code, and other MCP-compatible clients can **read** the plan, **explore branches**, and **write changes on a branch** — without copy-pasting specs into the chat. (MCP stands for [Model Context Protocol](https://modelcontextprotocol.io/).)
+Avo MCP ([Model Context Protocol](https://modelcontextprotocol.io/)) gives AI coding assistants direct access to your Avo tracking plan. Claude, ChatGPT, Cursor, Codex, Claude Code, and other MCP-compatible clients can **read** the plan, **explore branches**, and **write changes on a branch** — without copy-pasting specs into the chat.
 
 - **Transport:** Streamable HTTP at `https://mcp.avo.app/mcp`
 - **Authentication:** OAuth 2.0 + PKCE, scoped to your Avo identity
@@ -23,9 +23,7 @@ Avo MCP gives AI coding assistants direct access to your Avo tracking plan. Clau
 
 ## Use cases
 
-**Getting started.** Every tool except `list_workspaces` is workspace-scoped. Call `list_workspaces` first to find your `workspaceId`, then pass that ID to subsequent tool calls. (Stdio clients can also set the `WORKSPACE_ID` environment variable so it's picked up automatically.)
-
-The three use cases below cover the most common flows. Many more are possible through the same tools.
+**Getting started.** These tools let you search your tracking plan, design tracking for new features, and review Avo branches before you implement them. Start by calling `list_workspaces` to get your `workspaceId` — every other tool is scoped to a workspace, so you'll pass that ID into subsequent calls.
 
 ### Search the tracking plan
 
@@ -33,7 +31,7 @@ Ask Claude what's already instrumented — *"what events do we have for signup?"
 
 ### Design tracking for a new feature
 
-Share a PRD, Figma designs, or just a feature description. Claude reads your workspace's audit rules, hunts for items you can reuse, and proposes a plan — events, properties, metrics — for you to review before any write happens. On approval, it creates a branch and writes everything in a single batched call, using temporary IDs to attach a brand-new property to a brand-new event in the same write. The MCP never merges to main — you finalize the branch in the Avo web app.
+Share a PRD (product requirements document), Figma designs, or just a feature description. Claude reads your workspace's audit rules, hunts for items you can reuse, and proposes a plan — events, properties, metrics — for you to review before any write happens. On approval, it creates a branch and writes everything in a single batched call, using temporary IDs to attach a brand-new property to a brand-new event in the same write. The MCP never merges to main — you finalize the branch in the Avo web app.
 
 ### Review and implement an Avo branch
 
@@ -75,7 +73,7 @@ No. The MCP creates branches and writes items on them, but merging always remain
 
 ### What data does Avo collect through the MCP?
 
-The MCP reads and writes tracking-plan content — events, properties, event variants, metrics, categories, and property bundles — already stored in your Avo workspace. It does not collect your codebase, your prompts, or any data your MCP client sends to its model. Standard operational telemetry — request IDs, error counts — is retained for reliability. See the [Avo Privacy Policy](https://www.avo.app/l/privacy) for full details.
+The MCP reads and writes tracking-plan content — events, properties, event variants, metrics, categories, and property bundles — already stored in your Avo workspace. It does not collect your codebase, your prompts, or any data your MCP client sends to its model. Standard operational telemetry — request IDs, error counts — is retained for reliability. See the [Avo Privacy Policy](https://www.avo.app/privacy) for full details.
 
 ### Do I need to be a workspace admin to use the Avo MCP?
 
@@ -166,7 +164,7 @@ For bug reports, feature requests, or help connecting an MCP client, email [supp
 
 - **What is collected.** The MCP reads and writes tracking-plan content already stored in your Avo workspace. It does not collect your codebase, prompts, or data your MCP client sends to its model.
 - **How it's used.** Tool calls update your tracking plan or return its current state. Operational telemetry (request IDs, error counts) is collected for reliability and abuse prevention.
-- **Storage and retention.** Tracking-plan content lives in your Avo workspace under the existing retention policy. OAuth tokens and operational logs follow the schedule in the [Avo Privacy Policy](https://www.avo.app/l/privacy).
+- **Storage and retention.** Tracking-plan content lives in your Avo workspace under the existing retention policy. OAuth tokens and operational logs follow the schedule in the [Avo Privacy Policy](https://www.avo.app/privacy).
 - **Third-party sharing.** Avo does not forward tracking-plan content to AI providers. The MCP returns data to your client; your client decides what to send onward to its model.
 
-Full data-handling details are in the [Avo Privacy Policy](https://www.avo.app/l/privacy).
+Full data-handling details are in the [Avo Privacy Policy](https://www.avo.app/privacy).

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -676,3 +676,13 @@ Claude passes the user's email as `reviewerEmail` and filters status to `ReadyFo
 
 ---
 
+## Troubleshooting
+
+Tool-specific behavior issues. Authentication and workspace access issues are covered in [Troubleshooting on the overview page](/reference/avo-mcp/overview#troubleshooting).
+
+**[`search`](#search) returns nothing for a clearly relevant query.** Semantic search requires Avo Intelligence Smart Search to be enabled. Workspace admins can turn it on in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). Without it, fall back to [`get`](#get) with an exact name or [`search`](#search) in filter mode.
+
+**The wrong branch is returned by name.** `branchName` resolves to a best match and prioritizes open branches, so an ambiguous name can pick the wrong one. Resolve the name to a `branchId` with [`list_branches`](#list_branches) first and pass `branchId` to the follow-up call.
+
+**[`save_items`](#save_items) returns a `NotYetImplemented` error.** A small set of operations are not supported yet — removing event variants and changing a property's `sendAs`. See the [`save_items` reference](#save_items) for the full list.
+

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -57,7 +57,7 @@ Claude calls `list_workspaces` with no parameters and uses the returned `workspa
 
 Find tracking plan items in one of two modes — the mode is selected automatically by which parameters you pass. **Combining `query` with structural filters returns 400.** For ID-based lookups use [`get`](#get).
 
-- **Semantic search** — pass `query` to find items by meaning across events, properties, metrics, categories, property bundles, and event variants. Uses vector similarity, not keyword matching — `"user signed up"` matches `Account Created` or `Registration Completed`.
+- **Semantic search** — pass `query` to find items by meaning across events, properties, metrics, categories, property bundles, and event variants. Avo embeds each item with OpenAI embeddings and runs a vector-similarity search at query time, so `"user signed up"` matches `Account Created` or `Registration Completed` even when no keyword overlaps. Requires Avo Intelligence Smart Search to be enabled in [Workspace Settings](https://www.avo.app/schemas/default?settings=general).
 - **Structured listing** — omit `query` and pass filters to enumerate exact matches with keyset pagination.
 
 ### Parameters

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -57,8 +57,12 @@ Claude calls `list_workspaces` with no parameters and uses the returned `workspa
 
 Find tracking plan items in one of two modes — the mode is selected automatically by which parameters you pass. **Combining `query` with structural filters returns 400.** For ID-based lookups use [`get`](#get).
 
-- **Semantic search** — pass `query` to find items by meaning across events, properties, metrics, categories, property bundles, and event variants. Avo embeds each item with OpenAI embeddings and runs a vector-similarity search at query time, so `"user signed up"` matches `Account Created` or `Registration Completed` even when no keyword overlaps. Requires Avo Intelligence Smart Search to be enabled in [Workspace Settings](https://www.avo.app/schemas/default?settings=general).
+- **Semantic search** — pass `query` to find items by meaning across events, properties, metrics, categories, property bundles, and event variants. Avo embeds each item with OpenAI embeddings and runs a vector-similarity search at query time, so `"user signed up"` matches `Account Created` or `Registration Completed` even when no keyword overlaps.
 - **Structured listing** — omit `query` and pass filters to enumerate exact matches with keyset pagination.
+
+<Callout type="info" emoji="🔒">
+  Semantic search requires Avo Intelligence Smart Search to be enabled in your workspace. Workspace admins can enable it in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). If you don't have admin access, ask a workspace admin to enable it. Filter-mode listing does not require Smart Search.
+</Callout>
 
 ### Parameters
 
@@ -101,10 +105,6 @@ Semantic search is performed against the **main branch** only. The semantic inde
 | `pageToken` | No | Pagination token from a previous response. |
 
 Multiple values inside one array are OR'd; values across different filter keys are AND'd.
-
-<Callout type="info" emoji="🔒">
-  Semantic search requires Avo Intelligence Smart Search to be enabled in your workspace. Workspace admins can enable it in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). If you don't have admin access, ask a workspace admin to enable it. Filter-mode listing does not require Smart Search.
-</Callout>
 
 ### Returns
 

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -285,7 +285,7 @@ Batch create, update, remove, and archive events, properties, event variants, pr
 | `items` | Yes | Array of items to apply. Each item is typed by its `type` field and has an `op` (default `create`). |
 | `workspaceId` | No | Workspace ID |
 
-The request is capped at **100 items** per call.
+The request is capped at **50 items** per call.
 
 ### Item shape
 
@@ -293,18 +293,19 @@ Every item shares these fields:
 
 | Field | Type | Notes |
 |---|---|---|
-| `op` | `"create"` \| `"update"` \| `"remove"` \| `"archive"` | Defaults to `"create"`. Not every op applies to every type — see "Supported ops" below. For events, `"archive"` is the canonical archive op and `"remove"` is accepted as a legacy alias that behaves identically. For properties and property bundles, `"remove"` is the archive op (no `"archive"` variant). |
-| `type` | `"event"` \| `"property"` \| `"event_variant"` \| `"property_bundle"` \| `"metric"` | Required. |
-| `name` | string | Required on `create` for events, properties, property bundles, and metrics. Cosmetic on `event_variant` items and on `update`/`remove`/`archive` of other types. |
+| `op` | `"create"` \| `"update"` \| `"remove"` \| `"archive"` | Defaults to `"create"`. Not every op applies to every type — see "Supported ops" below. For events and event variants, `"archive"` is the canonical archive op and `"remove"` is accepted as a legacy alias for events (event variants accept only `"archive"`). For properties, property bundles, and categories, `"remove"` is the archive op (no `"archive"` variant). |
+| `type` | `"event"` \| `"property"` \| `"event_variant"` \| `"property_bundle"` \| `"metric"` \| `"category"` | Required. |
+| `name` | string | Required on `create` for events, properties, property bundles, metrics, and categories. Cosmetic on `event_variant` items and on `update`/`remove`/`archive` of other types. |
 | `tempId` | string | **Create only.** Declares a temporary handle (e.g. `"prop1"`). Reference it elsewhere in the same call as `"$tmp:prop1"`. The server allocates a real ID and resolves all `$tmp:` references before writing. |
 | `eventId` | string | Required on `update` / `archive` (or legacy `remove`) of events. |
 | `propertyId` | string | Required on `update` / `remove` of properties. |
 | `propertyBundleId` | string | Required on `update` / `remove` of property bundles. |
 | `metricId` | string | Required on `update` / `archive` of metrics. |
+| `categoryId` | string | Required on `update` / `remove` of categories. |
 | `baseEventId` | string | Required for `event_variant` items — the parent event's ID. |
-| `variantId` | string | Required on `update` of `event_variant`. On `create`, provide either `variantId` directly or a `tempId` on the same item. |
+| `variantId` | string | Required on `update` / `archive` of `event_variant`. On `create`, provide either `variantId` directly or a `tempId` on the same item. |
 | `nameSuffix` | string | Required on `create` of `event_variant` — suffix appended to the parent event name (e.g. `buy_now` produces `click / buy_now`). |
-| `description` | string | Create-only. Event / property / bundle / metric description. |
+| `description` | string | Create-only. Event / property / event variant / bundle / metric / category description. |
 
 **Supported ops by type:**
 
@@ -312,9 +313,10 @@ Every item shares these fields:
 |---|:-:|:-:|:-:|:-:|
 | `event` | ✅ | ✅ | ✅ (legacy alias for `archive`) | ✅ (archives the event) |
 | `property` | ✅ | ✅ | ✅ (archives the property + cascades references) | — |
-| `event_variant` | ✅ | ✅ | ❌ (see "Not yet implemented") | — |
+| `event_variant` | ✅ | ✅ | ❌ (see "Not yet implemented") | ✅ (archives the variant) |
 | `property_bundle` | ✅ | ✅ | ✅ (archives the bundle) | — |
 | `metric` | ✅ | ✅ | — | ✅ |
+| `category` | ✅ | ✅ | ✅ (archives the category; does **not** cascade) | — |
 
 **Create-event fields:**
 
@@ -324,6 +326,7 @@ Every item shares these fields:
 | `propertyBundles` | Array of property bundle IDs (or `$tmp:` refs) to attach to the event. |
 | `sources` | Array of source IDs to include the event in. Find source IDs with [`get`](#get) (`type: "source"` with `id`/`name` omitted to enumerate). |
 | `tags` | Array of literal tag-name strings to apply to the event. |
+| `nameMappings` | Per-destination name mappings. Array of tagged objects — `{ kind: "allDestinations", name: "..." }` to map across every destination, or `{ kind: "destination", destinationId: "...", name: "..." }` to map per destination. Also accepted on `update`-event items. |
 
 **Create-property fields:**
 
@@ -332,6 +335,7 @@ Every item shares these fields:
 | `propertyType` | `string`, `int`, `long`, `float`, `bool`, `object`, `any` (aliases like `integer`, `boolean`, `double` accepted). |
 | `sendAs` | `event`, `user`, or `system`. |
 | `tags` | Array of literal tag-name strings to apply to the property. |
+| `nameMappings` | Per-destination name mappings. Array of tagged objects — `{ kind: "allDestinations", name: "..." }` or `{ kind: "destination", destinationId: "...", name: "..." }`. Also accepted on `update`-property items. |
 | `eventConfigs` | *(optional)* Per-event/per-source property settings on a fresh property. On `create`, only `events: { kind: "allEvents" }` entries are accepted — per-event-scoped entries are rejected because the property isn't attached to any event yet. See "Per-event property settings (`eventConfigs`)" below. |
 
 **Create-event_variant fields:**
@@ -367,6 +371,7 @@ Every item shares these fields:
 | `addPropertyBundles` / `removePropertyBundles` | Property bundle IDs (or `$tmp:` refs) to attach / detach. |
 | `addSources` / `removeSources` | Source IDs to include / exclude. |
 | `addTags` / `removeTags` | **Top-level on the item, not inside `set`.** Tag-name strings to apply or remove. |
+| `addCategories` / `removeCategories` | **Top-level on the item.** Category **names** (or `$tmp:` refs to `create`-category items in the same batch) to add or remove. Note: categories are referenced by name, not ID. |
 
 **Update-event_variant fields:** _(require `baseEventId` + `variantId`)_
 
@@ -374,9 +379,19 @@ Every item shares these fields:
 |---|---|
 | `set.nameSuffix` | New variant suffix. |
 | `set.description` | New variant description. |
+| `set.triggers` | Replace the trigger list on the variant. |
 | `attachProperties` / `removeProperties` | Property IDs to attach / detach from this variant. |
+| `clearAttachedProperties` | Boolean — when `true`, detaches all properties from the variant in one call. |
 | `addComponentOverrides` | Override specs to add or replace. Same shape as create `overrides`. |
-| `removeComponentOverrides` | Property IDs whose overrides should be cleared. |
+| `removeComponentOverrides` | Property IDs whose component overrides should be cleared. |
+| `addSourceOverrides` / `removeSourceOverrides` | Source-override specs to add or remove. |
+| `clearSourceOverrides` | Boolean — when `true`, clears all source overrides on the variant. |
+| `addBundleOverrides` / `removeBundleOverrides` | Bundle-override specs to add or remove. |
+| `clearBundleOverrides` | Boolean — when `true`, clears all bundle overrides on the variant. |
+| `addVariantPropertyRegex` / `removeVariantPropertyRegex` | Variant property regex specs to add or remove. |
+| `clearVariantPropertyRegexOverride` | Boolean — when `true`, clears all variant property regex overrides. |
+
+The variant override surface uses a three-state lattice — `add*` / `remove*` / `clear*` — for attached properties, source overrides, bundle overrides, and variant property regex overrides. Use `add*` / `remove*` for incremental changes; use `clear*` only when you need to wipe the whole set in one call.
 
 **Update-property fields:** _(require `propertyId`)_
 
@@ -388,6 +403,7 @@ Every item shares these fields:
 | `addAllowedValues` | **Top-level on the item, not inside `set`.** String values to add to a string-typed property's allowed list. |
 | `removeAllowedValues` | **Top-level on the item, not inside `set`.** Values not in the current list are silently no-ops. |
 | `addTags` / `removeTags` | **Top-level on the item, not inside `set`.** Tag-name strings to apply or remove. |
+| `addCategories` / `removeCategories` | **Top-level on the item.** Category names (or `$tmp:` refs) to add or remove. Categories are referenced by name, not ID. |
 | `isList` | **Top-level on the item, not inside `set`.** Boolean — switches the property between scalar (`false`) and list (`true`). Property-only. |
 | `eventConfigs` | **Top-level on the item.** Per-event/per-source property settings — change presence, pin a value, or restrict allowed values per event. See "Per-event property settings (`eventConfigs`)" below. |
 
@@ -407,10 +423,22 @@ Every item shares these fields:
 | `setDescription` | New metric description. |
 | `addItems` / `removeItems` | For non-cohort metrics, add or remove metric items. |
 | `addCohortConditions` / `updateCohortConditions` / `removeCohortConditions` | For `Cohort` metrics, manage the cohort condition list. |
+| `addCategories` / `removeCategories` | **Top-level on the item.** Category names (or `$tmp:` refs) to add or remove. Categories are referenced by name, not ID. |
+
+**Update-category fields:** _(require `categoryId`)_
+
+| Field | Notes |
+|---|---|
+| `set.name` | Rename the category. |
+| `set.description` | New category description. |
 
 **Archive-event:** _(require `eventId`)_
 
 `{ op: "archive", type: "event", eventId: "..." }` archives the event on the branch. `{ op: "remove", type: "event", eventId: "..." }` is accepted as a legacy alias and behaves identically.
+
+**Archive-event_variant:** _(require `baseEventId` + `variantId`)_
+
+`{ op: "archive", type: "event_variant", baseEventId: "...", variantId: "..." }` archives the variant on the branch. Event variants accept only `op: "archive"` — `op: "remove"` is not supported.
 
 **Remove-property:** _(require `propertyId`)_
 
@@ -420,9 +448,36 @@ Every item shares these fields:
 
 `{ op: "remove", type: "property_bundle", propertyBundleId: "..." }` archives the bundle on the branch. Bundles use `op: "remove"` for archive — there is no separate `op: "archive"` for bundles.
 
+**Remove-category:** _(require `categoryId`)_
+
+`{ op: "remove", type: "category", categoryId: "..." }` archives the category on the branch. Categories use `op: "remove"` for archive — there is no separate `op: "archive"` for categories. Unlike `Remove-property`, this does **not** cascade — events, properties, and metrics that referenced the category keep their `addCategories` history pointing at the (now-archived) category. To migrate members to a different category first, see "Merging categories" below.
+
 **Archive-metric:** _(require `metricId`)_
 
 `{ op: "archive", type: "metric", metricId: "..." }` archives the metric on the branch.
+
+### Owner and stakeholder fields
+
+<Callout type="warning" emoji="⚠️">
+  **Branch-independent.** Owner and stakeholder assignments take effect **immediately workspace-wide**, even if the branch is later discarded. Discarding the branch will **not** roll back these changes. Treat these fields as out-of-branch mutations, not draft edits.
+</Callout>
+
+`owner` and `stakeholders` fields are accepted on event, property, and metric items (both `create` and `update`):
+
+| Field | Notes |
+|---|---|
+| `owner.stakeholder` | Sets the owning stakeholder. Reference must point to an existing stakeholder (stakeholders are created in the Avo web app — the MCP does not create them). |
+| `stakeholders.add` | Array of stakeholder references to add as collaborators. |
+| `stakeholders.remove` | Array of stakeholder references to remove as collaborators. |
+
+### Merging categories
+
+The MCP has no dedicated "merge categories" op. To merge category `A` into category `B`, send a single `save_items` batch containing:
+
+1. An `update` item for every event, property, and metric in `A` carrying `addCategories: ["B"], removeCategories: ["A"]`.
+2. A `{ op: "remove", type: "category", categoryId: "<id of A>" }` item.
+
+Both must travel in the same batch — the category removal in step 2 does **not** cascade to its members, so step 1 has to move the members first.
 
 ### Per-event property settings (`eventConfigs`)
 
@@ -440,7 +495,7 @@ Every item shares these fields:
   - `op: "remove"` on `event_variant` items
   - `set.sendAs` on `op: "update"` of `property` items — `sendAs` is immutable after create
 
-  Everything else works today: create / update events, properties, event variants, property bundles, metrics; archive events, properties, bundles, metrics; rename events and properties via `set.name`; toggle a property between scalar and list via `isList`; apply or remove tags via `addTags` / `removeTags`; per-event property settings via `eventConfigs`.
+  Everything else works today: create / update events, properties, event variants, property bundles, metrics, categories; archive events, event variants, properties, bundles, metrics, categories; rename events and properties via `set.name`; toggle a property between scalar and list via `isList`; apply or remove tags via `addTags` / `removeTags`; per-event property settings via `eventConfigs`.
 </Callout>
 
 ### Temporary IDs (`tempId` / `$tmp:`)
@@ -542,7 +597,7 @@ Claude creates a `Funnel` metric whose `items` reference two existing events in 
 - `Duplicate tempId "<name>"` — each `tempId` must be unique across items in the batch.
 - `Unknown $tmp: reference` — a `$tmp:` ref names a tempId that wasn't declared.
 - `<idField> is required for <op> <entity> items` — missing `eventId` / `propertyId` / `baseEventId` / `variantId` / `propertyBundleId` / `metricId`.
-- `too many items (got N, max 100)` — batch is over the 100-item cap.
+- `too many items (got N, max 50)` — batch is over the 50-item cap.
 - `NotYetImplemented` — one of the unsupported operations above.
 - Per-item audit-pipeline validation failures (e.g. illegal name, duplicate property, etc.) — returned inside the `errors` array rather than failing the whole call.
 ## `workflow`

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -54,139 +54,6 @@ Claude calls `list_workspaces` with no parameters and uses the returned `workspa
 
 ---
 
-## `list_branches`
-
-**Scope:** `read`
-
-<Callout type="info" emoji="🚧">
-  **Transitional.** This tool stays available while branch enumeration is being folded into [`search`](#search) with `type: "branch"`. Until that ships, use `list_branches` to enumerate branches.
-</Callout>
-
-Browse branches in a workspace with filtering and pagination. Results are paginated newest-first.
-
-### Parameters
-
-| Parameter | Required | Description |
-|---|---|---|
-| `workspaceId` | No | Workspace ID |
-| `branchStatuses` | No | Filter by status. Valid values: `Draft`, `ReadyForReview`, `ChangesRequested`, `Approved`, `Merged`, `Closed`, `Open`. Defaults to open/active branches only. |
-| `pageSize` | No | Results per page (1–50, default 25) |
-| `pageToken` | No | Pagination token from a previous response |
-| `branchName` | No | Substring match on branch name (case-insensitive) |
-| `creatorEmail` | No | Filter by creator email |
-| `creatorUserId` | No | Filter by creator user ID |
-| `reviewerEmail` | No | Filter by reviewer email |
-| `reviewerUserId` | No | Filter by reviewer user ID |
-| `collaboratorEmail` | No | Filter by collaborator email |
-| `collaboratorUserId` | No | Filter by collaborator user ID |
-| `createdAfter` | No | ISO 8601 date — only branches created after |
-| `createdBefore` | No | ISO 8601 date — only branches created before |
-| `impactedSourceId` | No | Filter to branches affecting a specific source |
-
-By default `Merged` and `Closed` branches are excluded. Pass `branchStatuses: ["Merged"]` (or any other value) to include them.
-
-<Callout type="info" emoji="💡">
-  To find "my branches," pass your own email as `creatorEmail` or `reviewerEmail`. The tool does not auto-inject your identity into the filter.
-</Callout>
-
-### Returns
-
-Compact per-branch summary — name, status, ID, creator email — plus a `nextPageToken` when more results are available. Call [`get`](#get) with `type: "branch"` and `include: ["overview"]` for full resolved data.
-
-### Examples
-
-#### Find branches I'm reviewing
-
-**Prompt:** *"What branches am I assigned to review?"*
-
-Claude passes the user's email as `reviewerEmail` and filters status to `ReadyForReview`. The tool does not auto-inject the caller's identity, so the email has to be supplied explicitly.
-
-```json
-{
-  "reviewerEmail": "thora@avo.sh",
-  "branchStatuses": ["ReadyForReview"]
-}
-```
-
-### Common errors
-
-- Workspace access denied.
-- Invalid `pageSize` (outside 1–50).
-- Invalid date format on `createdAfter` / `createdBefore`.
-
----
-
-## `get`
-
-**Scope:** `read`
-
-Universal item-details tool. Look up a single tracking plan item by ID or exact name, read a branch's overview and code snippets, or enumerate workspace-level entities. Defaults to the main branch.
-
-### Parameters
-
-| Parameter | Required | Description |
-|---|---|---|
-| `type` | Yes | Item type. One of: `event`, `property`, `metric`, `category`, `propertyBundle`, `source`, `destination`, `groupType`, `eventVariant`, `branch`, `workspaceConfig`. |
-| `id` | Varies by type | The item's unique ID. Required for `event`, `property`, `metric`, `category`, `propertyBundle`, `eventVariant` unless `name` is provided. Optional for `source`/`destination`/`groupType` (omit both `id` and `name` to enumerate). Optional for `branch` (defaults to the active branch context if omitted). Not used by `workspaceConfig`. |
-| `name` | Varies by type | Exact name match. Alternative to `id` for most types. May return multiple matches for ambiguous names (especially properties) — use [`search`](#search) for fuzzy lookup. |
-| `variantId` | For `eventVariant` | The variant ID. Combined with `id` (the base event ID). |
-| `include` | For `branch` | Array of branch facets to return: `overview`, `changes`, `code_snippets`. Combine `changes` and `code_snippets` for an implementer-ready picture of the branch. |
-| `sourceId` | When `include` contains `code_snippets` | Source ID to scope the code snippets to. |
-| `branchId` | No | Branch to look up on. Defaults to main. `branchId` takes precedence over `branchName`. |
-| `branchName` | No | Alternative to `branchId`. |
-| `includePropertyDetails` | No | Events only. When `true`, includes full property definitions (type, constraints, allowed values). Defaults to `false`, which returns only property ID + name references. |
-| `includeArchived` | No | When `true` (default), includes archived items in results. When `false`, only active items. |
-| `workspaceId` | No | Workspace ID |
-
-### Returns
-
-Full details for the item, shaped per item type.
-
-- `type: "event" \| "property" \| "metric" \| "category" \| "propertyBundle" \| "eventVariant"` — the item's full definition.
-- `type: "source" \| "destination" \| "groupType"` — a single entity when `id`/`name` is provided, or a workspace-level list when both are omitted.
-- `type: "branch"` — branch facets requested via `include`. `overview` returns resolved emails for the creator, reviewers, and collaborators, branch status, impacted source IDs, and description. `changes` returns the structured diff (new, modified, and deleted events with their properties and descriptions). `code_snippets` returns per-event code diffs for the source named in `sourceId` — exact unified diffs for [Avo Codegen](/implementation/avo-codegen-overview) sources and illustrative pseudocode for manually-instrumented sources.
-- `type: "workspaceConfig"` — the workspace's event/property naming conventions and casing rules, plus custom field definitions and the list of recognized PII types. Use this before proposing new events or properties so names match the workspace's audit rules.
-
-### Examples
-
-#### Look up an event by exact name
-
-**Prompt:** *"How is the `Account Created` event defined?"*
-
-Claude calls `get` with the exact name and `includePropertyDetails: true` so the response includes each attached property's type, constraints, and allowed values. Useful when the agent already knows the canonical name and wants the full schema in one call.
-
-```json
-{
-  "type": "event",
-  "name": "Account Created",
-  "includePropertyDetails": true
-}
-```
-
-#### Read what changed on a branch
-
-**Prompt:** *"What's on the `checkout-v2` branch — and can you show me the iOS code diff?"*
-
-Claude calls `get` with `type: "branch"` and combines `changes` and `code_snippets` in `include`. `sourceId` scopes the diff to a single source.
-
-```json
-{
-  "type": "branch",
-  "branchName": "checkout-v2",
-  "include": ["changes", "code_snippets"],
-  "sourceId": "src-ios"
-}
-```
-
-### Common errors
-
-- Item not found.
-- Ambiguous name (returns multiple matches — narrow by ID).
-- `sourceId` missing when `include` contains `code_snippets`.
-- Workspace access denied.
-
----
-
 ## `search`
 
 **Scope:** `read`
@@ -229,6 +96,8 @@ Semantic search is performed against the **main branch** only. The semantic inde
 | `owners` | No | Filter by owner. |
 | `destinations` | No | Filter by destination name. |
 | `type` | No | With `itemType: "event"`, filter by event type. |
+| `customField` | No | Filter by custom-field name. Resolve valid names from [`get`](#get) with `type: "workspaceConfig"`. |
+| `pii` | No | Filter by PII type. Resolve valid types from [`get`](#get) with `type: "workspaceConfig"`. |
 | `nameMapping` | No | Filter by destination-name-mapping. Tagged object: `{ kind: "any" }` (items with any mapping) or `{ kind: "matchesAny", names: [...], includeNoMapping?: bool }` (items whose mapped name is in `names`; with `includeNoMapping: true` items without a mapping rule also pass). Omitting `nameMapping` means no filter on mapping. |
 | `branchId` | No | Branch to enumerate on. Defaults to main. |
 | `branchName` | No | Alternative to `branchId`. |
@@ -306,72 +175,81 @@ Filter mode is selected by omitting `query`. Multiple filter keys are AND'd, so 
 
 ---
 
-## `workflow`
+## `get`
 
-**Scope:** `write`
+**Scope:** `read`
 
-<Callout type="info" emoji="🚧">
-  Write access is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
-</Callout>
+Get item details for any of four type families:
 
-Branch-lifecycle write operations. Currently supports two actions:
+- **Tracking-plan items** — `event`, `property`, `metric`, `category`, `propertyBundle`, `eventVariant`. Look up by `id` or exact `name`. For events, `includePropertyDetails: true` returns each property's type, constraints, and allowed values inline.
+- **Workspace metadata** — `source`, `destination`, `groupType`. Pass `id` or `name` for one item; omit both to enumerate the workspace list.
+- **Workspace config** — `workspaceConfig`. Naming/casing rules, custom-field definitions, and the PII type list. Custom-field and PII-type names plug straight into [`search`'s](#search) `customField` and `pii` filters.
+- **Branches** — `branch`. Identify with `branchId` or `branchName`. Use `include` to pick content: `"overview"` (branch metadata + baseline status), `"changes"` (diff vs. main, like the web branch screen), `"code_snippets"` (per-source generated code; requires `sourceId`). `include` defaults to `["overview"]`.
 
-- `create_branch` — open a new branch.
-- `update_branch_description` — set the description on an existing open branch.
-
-<Callout type="info" emoji="💡">
-  A branch is a draft workspace for tracking-plan changes, analogous to a git branch. All write operations via the MCP happen on a branch — `save_items` requires a `branchId` that exists. The MCP never merges to main; open the branch in the Avo app to review and merge.
-</Callout>
+Defaults to the main branch when no branch is specified.
 
 ### Parameters
 
 | Parameter | Required | Description |
 |---|---|---|
-| `action` | Yes | The workflow action. One of: `create_branch`, `update_branch_description`. |
-| `branchName` | For `create_branch`; alternative to `branchId` for `update_branch_description` | Name for the new branch (`create_branch`), or the existing branch's name (`update_branch_description`). |
-| `branchId` | Alternative to `branchName` for `update_branch_description` | ID of the existing branch to update. Provide exactly one of `branchId` or `branchName`. |
-| `description` | For `update_branch_description` | The new description text. |
+| `type` | Yes | Item type. One of: `event`, `property`, `metric`, `category`, `propertyBundle`, `source`, `destination`, `groupType`, `eventVariant`, `branch`, `workspaceConfig`. |
+| `id` | Varies by type | The item's unique ID. Required for `event`, `property`, `metric`, `category`, `propertyBundle`, `eventVariant` unless `name` is provided. Optional for `source`/`destination`/`groupType` (omit both `id` and `name` to enumerate). Optional for `branch` (defaults to the active branch context if omitted). Not used by `workspaceConfig`. |
+| `name` | Varies by type | Exact name match. Alternative to `id` for most types. May return multiple matches for ambiguous names (especially properties) — use [`search`](#search) for fuzzy lookup. |
+| `variantId` | For `eventVariant` | The variant ID. Combined with `id` (the base event ID). |
+| `include` | For `branch` | Array of branch facets to return: `overview`, `changes`, `code_snippets`. Defaults to `["overview"]`. Combine `changes` and `code_snippets` for an implementer-ready picture of the branch. |
+| `sourceId` | When `include` contains `code_snippets` | Source ID to scope the code snippets to. |
+| `branchId` | No | Branch to look up on. Defaults to main. `branchId` takes precedence over `branchName`. |
+| `branchName` | No | Alternative to `branchId`. |
+| `includePropertyDetails` | No | Events only. When `true`, includes full property definitions (type, constraints, allowed values). Defaults to `false`, which returns only property ID + name references. |
+| `includeArchived` | No | When `true` (default), includes archived items in results. When `false`, only active items. |
 | `workspaceId` | No | Workspace ID |
 
 ### Returns
 
-For `create_branch`: the new branch's `branchId`, `branchName`, and a `branchUrl` that opens it in the Avo web app. For `update_branch_description`: confirmation with the resolved `branchId` and the updated description.
+Full details for the item, shaped per item type.
+
+- `type: "event" \| "property" \| "metric" \| "category" \| "propertyBundle" \| "eventVariant"` — the item's full definition.
+- `type: "source" \| "destination" \| "groupType"` — a single entity when `id`/`name` is provided, or a workspace-level list when both are omitted.
+- `type: "branch"` — branch facets requested via `include`. `overview` returns resolved emails for the creator, reviewers, and collaborators, branch status, impacted source IDs, and description. `changes` returns the structured diff (new, modified, and deleted events with their properties and descriptions). `code_snippets` returns per-event code diffs for the source named in `sourceId` — exact unified diffs for [Avo Codegen](/implementation/avo-codegen-overview) sources and illustrative pseudocode for manually-instrumented sources.
+- `type: "workspaceConfig"` — the workspace's event/property naming conventions and casing rules, plus custom field definitions and the list of recognized PII types. Use this before proposing new events or properties so names match the workspace's audit rules.
 
 ### Examples
 
-#### Create a branch for a new feature
+#### Look up an event by exact name
 
-**Prompt:** *"Start an Avo branch for the new checkout flow we're shipping next sprint."*
+**Prompt:** *"How is the `Account Created` event defined?"*
 
-Claude calls `workflow` with `action: "create_branch"` and a descriptive `branchName`. The returned `branchId` is required for the follow-up `save_items` calls that write the new events and properties.
+Claude calls `get` with the exact name and `includePropertyDetails: true` so the response includes each attached property's type, constraints, and allowed values. Useful when the agent already knows the canonical name and wants the full schema in one call.
 
 ```json
 {
-  "action": "create_branch",
-  "branchName": "add-checkout-tracking"
+  "type": "event",
+  "name": "Account Created",
+  "includePropertyDetails": true
 }
 ```
 
-#### Update a branch's description
+#### Read what changed on a branch
 
-**Prompt:** *"Update the description on the `add-checkout-tracking` branch to mention that we're now also tracking abandonment."*
+**Prompt:** *"What's on the `checkout-v2` branch — and can you show me the iOS code diff?"*
 
-Claude looks up the branch by name (no separate `branchId` lookup needed for this action) and replaces the description in one call.
+Claude calls `get` with `type: "branch"` and combines `changes` and `code_snippets` in `include`. `sourceId` scopes the diff to a single source.
 
 ```json
 {
-  "action": "update_branch_description",
-  "branchName": "add-checkout-tracking",
-  "description": "Adds the Checkout Completed and Checkout Abandoned events with the Checkout Method property."
+  "type": "branch",
+  "branchName": "checkout-v2",
+  "include": ["changes", "code_snippets"],
+  "sourceId": "src-ios"
 }
 ```
 
 ### Common errors
 
-- Missing `write` scope — re-authorize with `write`.
+- Item not found.
+- Ambiguous name (returns multiple matches — narrow by ID).
+- `sourceId` missing when `include` contains `code_snippets`.
 - Workspace access denied.
-- Unsupported action value.
-- Both `branchId` and `branchName` provided — `update_branch_description` requires exactly one.
 
 ---
 
@@ -403,11 +281,11 @@ Every item shares these fields:
 
 | Field | Type | Notes |
 |---|---|---|
-| `op` | `"create"` \| `"update"` \| `"remove"` \| `"archive"` | Defaults to `"create"`. Not every op applies to every type — see "Supported ops" below. |
+| `op` | `"create"` \| `"update"` \| `"remove"` \| `"archive"` | Defaults to `"create"`. Not every op applies to every type — see "Supported ops" below. For events, `"archive"` is the canonical archive op and `"remove"` is accepted as a legacy alias that behaves identically. For properties and property bundles, `"remove"` is the archive op (no `"archive"` variant). |
 | `type` | `"event"` \| `"property"` \| `"event_variant"` \| `"property_bundle"` \| `"metric"` | Required. |
-| `name` | string | Required on `create` for events, properties, property bundles, and metrics. Cosmetic on `event_variant` items and on `update`/`remove` of other types. |
+| `name` | string | Required on `create` for events, properties, property bundles, and metrics. Cosmetic on `event_variant` items and on `update`/`remove`/`archive` of other types. |
 | `tempId` | string | **Create only.** Declares a temporary handle (e.g. `"prop1"`). Reference it elsewhere in the same call as `"$tmp:prop1"`. The server allocates a real ID and resolves all `$tmp:` references before writing. |
-| `eventId` | string | Required on `update` / `remove` of events. |
+| `eventId` | string | Required on `update` / `archive` (or legacy `remove`) of events. |
 | `propertyId` | string | Required on `update` / `remove` of properties. |
 | `propertyBundleId` | string | Required on `update` / `remove` of property bundles. |
 | `metricId` | string | Required on `update` / `archive` of metrics. |
@@ -420,7 +298,7 @@ Every item shares these fields:
 
 | Type | create | update | remove | archive |
 |---|:-:|:-:|:-:|:-:|
-| `event` | ✅ | ✅ | ❌ (see "Not yet implemented") | — |
+| `event` | ✅ | ✅ | ✅ (legacy alias for `archive`) | ✅ (archives the event) |
 | `property` | ✅ | ✅ | ✅ (archives the property + cascades references) | — |
 | `event_variant` | ✅ | ✅ | ❌ (see "Not yet implemented") | — |
 | `property_bundle` | ✅ | ✅ | ✅ (archives the bundle) | — |
@@ -433,6 +311,7 @@ Every item shares these fields:
 | `properties` | Array of property IDs (or `$tmp:` refs) to attach. |
 | `propertyBundles` | Array of property bundle IDs (or `$tmp:` refs) to attach to the event. |
 | `sources` | Array of source IDs to include the event in. Find source IDs with [`get`](#get) (`type: "source"` with `id`/`name` omitted to enumerate). |
+| `tags` | Array of literal tag-name strings to apply to the event. |
 
 **Create-property fields:**
 
@@ -440,6 +319,7 @@ Every item shares these fields:
 |---|---|
 | `propertyType` | `string`, `int`, `long`, `float`, `bool`, `object`, `any` (aliases like `integer`, `boolean`, `double` accepted). |
 | `sendAs` | `event`, `user`, or `system`. |
+| `tags` | Array of literal tag-name strings to apply to the property. |
 | `eventConfigs` | *(optional)* Per-event/per-source property settings on a fresh property. On `create`, only `events: { kind: "allEvents" }` entries are accepted — per-event-scoped entries are rejected because the property isn't attached to any event yet. See "Per-event property settings (`eventConfigs`)" below. |
 
 **Create-event_variant fields:**
@@ -469,10 +349,12 @@ Every item shares these fields:
 
 | Field | Notes |
 |---|---|
+| `set.name` | Rename the event. Renaming to the same name is a no-op; renaming to a name already held by another live event is rejected. |
 | `set.description` | New event description. |
 | `addProperties` / `removeProperties` | Property IDs (or `$tmp:` refs) to associate / disassociate. |
 | `addPropertyBundles` / `removePropertyBundles` | Property bundle IDs (or `$tmp:` refs) to attach / detach. |
 | `addSources` / `removeSources` | Source IDs to include / exclude. |
+| `addTags` / `removeTags` | **Top-level on the item, not inside `set`.** Tag-name strings to apply or remove. |
 
 **Update-event_variant fields:** _(require `baseEventId` + `variantId`)_
 
@@ -488,10 +370,13 @@ Every item shares these fields:
 
 | Field | Notes |
 |---|---|
+| `set.name` | Rename the property. Renaming to the same name is a no-op; renaming to a name already held by another live property is rejected. |
 | `set.description` | New property description. |
 | `set.propertyType` | New type. Same value set as create: `string`, `int`, `long`, `float`, `bool`, `object`, `any` (aliases like `integer`, `boolean`, `double` accepted). |
 | `addAllowedValues` | **Top-level on the item, not inside `set`.** String values to add to a string-typed property's allowed list. |
 | `removeAllowedValues` | **Top-level on the item, not inside `set`.** Values not in the current list are silently no-ops. |
+| `addTags` / `removeTags` | **Top-level on the item, not inside `set`.** Tag-name strings to apply or remove. |
+| `isList` | **Top-level on the item, not inside `set`.** Boolean — switches the property between scalar (`false`) and list (`true`). Property-only. |
 | `eventConfigs` | **Top-level on the item.** Per-event/per-source property settings — change presence, pin a value, or restrict allowed values per event. See "Per-event property settings (`eventConfigs`)" below. |
 
 **Update-property_bundle fields:** _(require `propertyBundleId`)_
@@ -511,13 +396,17 @@ Every item shares these fields:
 | `addItems` / `removeItems` | For non-cohort metrics, add or remove metric items. |
 | `addCohortConditions` / `updateCohortConditions` / `removeCohortConditions` | For `Cohort` metrics, manage the cohort condition list. |
 
+**Archive-event:** _(require `eventId`)_
+
+`{ op: "archive", type: "event", eventId: "..." }` archives the event on the branch. `{ op: "remove", type: "event", eventId: "..." }` is accepted as a legacy alias and behaves identically.
+
 **Remove-property:** _(require `propertyId`)_
 
-`{ op: "remove", type: "property", propertyId: "..." }` archives the property on the branch and cascades removal references on every event that uses it, mirroring the Avo UI. The action is destructive but reversible from the Avo app. If you only have the property name, look up the ID first with [`get`](#get) or [`search`](#search) so that any name-conflict ambiguity is surfaced before the mutation runs.
+`{ op: "remove", type: "property", propertyId: "..." }` archives the property on the branch and cascades removal references on every event that uses it, mirroring the Avo UI. Properties use `op: "remove"` for archive — there is no separate `op: "archive"` for properties. The action is destructive but reversible from the Avo app. If you only have the property name, look up the ID first with [`get`](#get) or [`search`](#search) so that any name-conflict ambiguity is surfaced before the mutation runs.
 
 **Remove-property_bundle:** _(require `propertyBundleId`)_
 
-`{ op: "remove", type: "property_bundle", propertyBundleId: "..." }` archives the bundle on the branch.
+`{ op: "remove", type: "property_bundle", propertyBundleId: "..." }` archives the bundle on the branch. Bundles use `op: "remove"` for archive — there is no separate `op: "archive"` for bundles.
 
 **Archive-metric:** _(require `metricId`)_
 
@@ -536,11 +425,10 @@ Every item shares these fields:
 <Callout type="warning" emoji="🚧">
   **Not yet implemented.** The following return a `NotYetImplemented` error from the server:
 
-  - `op: "remove"` on `event` items (archiving events)
   - `op: "remove"` on `event_variant` items
   - `set.sendAs` on `op: "update"` of `property` items — `sendAs` is immutable after create
 
-  Everything else works today: create / update events, properties, event variants, property bundles, metrics; archive properties, bundles, metrics; per-event property settings via `eventConfigs`.
+  Everything else works today: create / update events, properties, event variants, property bundles, metrics; archive events, properties, bundles, metrics; rename events and properties via `set.name`; toggle a property between scalar and list via `isList`; apply or remove tags via `addTags` / `removeTags`; per-event property settings via `eventConfigs`.
 </Callout>
 
 ### Temporary IDs (`tempId` / `$tmp:`)
@@ -645,3 +533,134 @@ Claude creates a `Funnel` metric whose `items` reference two existing events in 
 - `too many items (got N, max 100)` — batch is over the 100-item cap.
 - `NotYetImplemented` — one of the unsupported operations above.
 - Per-item audit-pipeline validation failures (e.g. illegal name, duplicate property, etc.) — returned inside the `errors` array rather than failing the whole call.
+## `workflow`
+
+**Scope:** `write`
+
+<Callout type="info" emoji="🚧">
+  Write access is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
+</Callout>
+
+Branch-lifecycle write operations. Currently supports two actions:
+
+- `create_branch` — open a new branch.
+- `update_branch_description` — set the description on an existing open branch.
+
+<Callout type="info" emoji="💡">
+  A branch is a draft workspace for tracking-plan changes, analogous to a git branch. All write operations via the MCP happen on a branch — `save_items` requires a `branchId` that exists. The MCP never merges to main; open the branch in the Avo app to review and merge.
+</Callout>
+
+### Parameters
+
+| Parameter | Required | Description |
+|---|---|---|
+| `action` | Yes | The workflow action. One of: `create_branch`, `update_branch_description`. |
+| `branchName` | For `create_branch`; alternative to `branchId` for `update_branch_description` | Name for the new branch (`create_branch`), or the existing branch's name (`update_branch_description`). |
+| `branchId` | Alternative to `branchName` for `update_branch_description` | ID of the existing branch to update. Provide exactly one of `branchId` or `branchName`. |
+| `description` | For `update_branch_description` | The new description text. |
+| `workspaceId` | No | Workspace ID |
+
+### Returns
+
+For `create_branch`: the new branch's `branchId`, `branchName`, and a `branchUrl` that opens it in the Avo web app. For `update_branch_description`: confirmation with the resolved `branchId` and the updated description.
+
+### Examples
+
+#### Create a branch for a new feature
+
+**Prompt:** *"Start an Avo branch for the new checkout flow we're shipping next sprint."*
+
+Claude calls `workflow` with `action: "create_branch"` and a descriptive `branchName`. The returned `branchId` is required for the follow-up `save_items` calls that write the new events and properties.
+
+```json
+{
+  "action": "create_branch",
+  "branchName": "add-checkout-tracking"
+}
+```
+
+#### Update a branch's description
+
+**Prompt:** *"Update the description on the `add-checkout-tracking` branch to mention that we're now also tracking abandonment."*
+
+Claude looks up the branch by name (no separate `branchId` lookup needed for this action) and replaces the description in one call.
+
+```json
+{
+  "action": "update_branch_description",
+  "branchName": "add-checkout-tracking",
+  "description": "Adds the Checkout Completed and Checkout Abandoned events with the Checkout Method property."
+}
+```
+
+### Common errors
+
+- Missing `write` scope — re-authorize with `write`.
+- Workspace access denied.
+- Unsupported action value.
+- Both `branchId` and `branchName` provided — `update_branch_description` requires exactly one.
+
+---
+
+## `list_branches`
+
+**Scope:** `read`
+
+<Callout type="info" emoji="🚧">
+  **Transitional.** This tool stays available while branch enumeration is being folded into [`search`](#search) with `type: "branch"`. Until that ships, use `list_branches` to enumerate branches.
+</Callout>
+
+Browse branches in a workspace with filtering and pagination. Results are paginated newest-first.
+
+### Parameters
+
+| Parameter | Required | Description |
+|---|---|---|
+| `workspaceId` | No | Workspace ID |
+| `branchStatuses` | No | Filter by status. Valid values: `Draft`, `ReadyForReview`, `ChangesRequested`, `Approved`, `Merged`, `Closed`, `Open`. Defaults to open/active branches only. |
+| `pageSize` | No | Results per page (1–50, default 25) |
+| `pageToken` | No | Pagination token from a previous response |
+| `branchName` | No | Substring match on branch name (case-insensitive) |
+| `creatorEmail` | No | Filter by creator email |
+| `creatorUserId` | No | Filter by creator user ID |
+| `reviewerEmail` | No | Filter by reviewer email |
+| `reviewerUserId` | No | Filter by reviewer user ID |
+| `collaboratorEmail` | No | Filter by collaborator email |
+| `collaboratorUserId` | No | Filter by collaborator user ID |
+| `createdAfter` | No | ISO 8601 date — only branches created after |
+| `createdBefore` | No | ISO 8601 date — only branches created before |
+| `impactedSourceId` | No | Filter to branches affecting a specific source |
+
+By default `Merged` and `Closed` branches are excluded. Pass `branchStatuses: ["Merged"]` (or any other value) to include them.
+
+<Callout type="info" emoji="💡">
+  To find "my branches," pass your own email as `creatorEmail` or `reviewerEmail`. The tool does not auto-inject your identity into the filter.
+</Callout>
+
+### Returns
+
+Compact per-branch summary — name, status, ID, creator email — plus a `nextPageToken` when more results are available. Call [`get`](#get) with `type: "branch"` and `include: ["overview"]` for full resolved data.
+
+### Examples
+
+#### Find branches I'm reviewing
+
+**Prompt:** *"What branches am I assigned to review?"*
+
+Claude passes the user's email as `reviewerEmail` and filters status to `ReadyForReview`. The tool does not auto-inject the caller's identity, so the email has to be supplied explicitly.
+
+```json
+{
+  "reviewerEmail": "thora@avo.sh",
+  "branchStatuses": ["ReadyForReview"]
+}
+```
+
+### Common errors
+
+- Workspace access denied.
+- Invalid `pageSize` (outside 1–50).
+- Invalid date format on `createdAfter` / `createdBefore`.
+
+---
+

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -432,7 +432,7 @@ Every item shares these fields:
 - **`setPinnedValue`** — pin a value for the property. With `events: { kind: "onEvent" }` pins per-event; with `events: { kind: "allEvents" }` pins property-wide.
 - **`restrictAllowedValues`** — change the property's allowed value list for an event. Carries a `valuesChange` delta: `addValues` (non-empty), `removeValues`, or `clear` (no payload).
 
-`eventConfigs` entries reference pre-existing events — a same-batch `create`-event item isn't visible to `eventConfigs` yet, so create the event in an earlier call (or the same batch, ordered before the property update that references it).
+`eventConfigs` entries can only reference events that existed before the current batch started — `$tmp:` references are not supported in `eventConfigs` fields, so a `create`-event item earlier in the same batch is not visible to `eventConfigs`. Create the event in an earlier `save_items` call, then reference its real `eventId` from `eventConfigs`.
 
 <Callout type="warning" emoji="🚧">
   **Not yet implemented.** The following return a `NotYetImplemented` error from the server:

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -5,28 +5,20 @@ import { Callout } from 'nextra/components'
 Every tool except `list_workspaces` operates on a workspace. Pass `workspaceId` as a parameter; stdio clients can also set the `WORKSPACE_ID` environment variable.
 
 <Callout type="info" emoji="🔒">
-  Tools are grouped below by intent. Each tool lists the OAuth scope required. Write tools (`workflow`, `save_items`) require the `write` scope, which is requested as a separate consent step on first use.
+  Each tool lists the OAuth scope it requires. Write tools (`workflow`, `save_items`) require the `write` scope, which is requested as a separate consent step on first use.
 </Callout>
 
-The MCP maps five canonical tools to agent intents:
+The MCP exposes five canonical tools mapped to agent intents:
 
-**Entry point**
-- [`list_workspaces`](#list_workspaces) — find your workspace IDs
+| Intent | Tool | Scope |
+|---|---|---|
+| **Entry point** — find your workspace IDs | [`list_workspaces`](#list_workspaces) | `read` |
+| **Discover** — find items by meaning or by structural filter | [`search`](#search) | `read` |
+| **Understand** — full details for an event, property, branch, source, etc. | [`get`](#get) | `read` |
+| **Change** — create, update, remove, or archive items on a branch | [`save_items`](#save_items) | `write` |
+| **Progress** — create a branch or update its description | [`workflow`](#workflow) | `write` |
 
-**Discover** *(read)*
-- [`search`](#search) — find items by meaning or by structural filter
-
-**Understand** *(read)*
-- [`get`](#get) — full details for any tracking plan item (or a branch overview / code snippets)
-
-**Change** *(write)*
-- [`save_items`](#save_items) — create, update, remove, or archive events, properties, event variants, property bundles, and metrics on a branch
-
-**Progress** *(write)*
-- [`workflow`](#workflow) — create a branch or update its description
-
-**Transitional** *(read — kept while its replacement ships)*
-- [`list_branches`](#list_branches) — browse branches (planned: folded into `search(type:"branch")`)
+Branch read flows are covered by `get` and `search`. One transitional tool — [`list_branches`](#list_branches) — remains available while its replacement in `search(type:"branch")` ships.
 
 ---
 

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -34,13 +34,23 @@ The MCP maps five canonical tools to agent intents:
 
 **Scope:** `read`
 
-List the Avo workspaces the authenticated user has access to.
+List the Avo workspaces the authenticated user has access to. Call this first to discover workspace IDs before invoking any workspace-scoped tool.
 
-**Parameters:** None
+### Parameters
 
-**Returns:** One row per workspace: name, workspace ID, and the user's role.
+None.
 
-Call this first to discover workspace IDs before invoking any workspace-scoped tool.
+### Returns
+
+One row per workspace: name, workspace ID, and the user's role.
+
+### Examples
+
+#### Discover the workspaces you can access
+
+**Prompt:** *"What Avo workspaces do I have access to?"*
+
+Claude calls `list_workspaces` with no parameters and uses the returned `workspaceId` to scope every other tool call in the session.
 
 ---
 
@@ -54,7 +64,7 @@ Call this first to discover workspace IDs before invoking any workspace-scoped t
 
 Browse branches in a workspace with filtering and pagination. Results are paginated newest-first.
 
-**Parameters:**
+### Parameters
 
 | Parameter | Required | Description |
 |---|---|---|
@@ -73,15 +83,36 @@ Browse branches in a workspace with filtering and pagination. Results are pagina
 | `createdBefore` | No | ISO 8601 date — only branches created before |
 | `impactedSourceId` | No | Filter to branches affecting a specific source |
 
-**Returns:** Compact per-branch summary — name, status, ID, creator email — plus a `nextPageToken` when more results are available. Call [`get`](#get) with `type: "branch"` and `include: ["overview"]` for full resolved data.
+By default `Merged` and `Closed` branches are excluded. Pass `branchStatuses: ["Merged"]` (or any other value) to include them.
 
 <Callout type="info" emoji="💡">
   To find "my branches," pass your own email as `creatorEmail` or `reviewerEmail`. The tool does not auto-inject your identity into the filter.
 </Callout>
 
-By default `Merged` and `Closed` branches are excluded. Pass `branchStatuses: ["Merged"]` (or any other value) to include them.
+### Returns
 
-**Common errors:** workspace access denied, invalid `pageSize`, invalid date format.
+Compact per-branch summary — name, status, ID, creator email — plus a `nextPageToken` when more results are available. Call [`get`](#get) with `type: "branch"` and `include: ["overview"]` for full resolved data.
+
+### Examples
+
+#### Find branches I'm reviewing
+
+**Prompt:** *"What branches am I assigned to review?"*
+
+Claude passes the user's email as `reviewerEmail` and filters status to `ReadyForReview`. The tool does not auto-inject the caller's identity, so the email has to be supplied explicitly.
+
+```json
+{
+  "reviewerEmail": "thora@avo.sh",
+  "branchStatuses": ["ReadyForReview"]
+}
+```
+
+### Common errors
+
+- Workspace access denied.
+- Invalid `pageSize` (outside 1–50).
+- Invalid date format on `createdAfter` / `createdBefore`.
 
 ---
 
@@ -91,7 +122,7 @@ By default `Merged` and `Closed` branches are excluded. Pass `branchStatuses: ["
 
 Universal item-details tool. Look up a single tracking plan item by ID or exact name, read a branch's overview and code snippets, or enumerate workspace-level entities. Defaults to the main branch.
 
-**Parameters:**
+### Parameters
 
 | Parameter | Required | Description |
 |---|---|---|
@@ -107,14 +138,52 @@ Universal item-details tool. Look up a single tracking plan item by ID or exact 
 | `includeArchived` | No | When `true` (default), includes archived items in results. When `false`, only active items. |
 | `workspaceId` | No | Workspace ID |
 
-**Returns:** Full details for the item, shaped per item type.
+### Returns
+
+Full details for the item, shaped per item type.
 
 - `type: "event" \| "property" \| "metric" \| "category" \| "propertyBundle" \| "eventVariant"` — the item's full definition.
 - `type: "source" \| "destination" \| "groupType"` — a single entity when `id`/`name` is provided, or a workspace-level list when both are omitted.
 - `type: "branch"` — branch facets requested via `include`. `overview` returns resolved emails for the creator, reviewers, and collaborators, branch status, impacted source IDs, and description. `changes` returns the structured diff (new, modified, and deleted events with their properties and descriptions). `code_snippets` returns per-event code diffs for the source named in `sourceId` — exact unified diffs for [Avo Codegen](/implementation/avo-codegen-overview) sources and illustrative pseudocode for manually-instrumented sources.
 - `type: "workspaceConfig"` — the workspace's event/property naming conventions and casing rules, plus custom field definitions and the list of recognized PII types. Use this before proposing new events or properties so names match the workspace's audit rules.
 
-**Common errors:** item not found, ambiguous name (returns multiple matches — narrow by ID), `sourceId` missing for `include: ["code_snippets"]`, workspace access denied.
+### Examples
+
+#### Look up an event by exact name
+
+**Prompt:** *"How is the `Account Created` event defined?"*
+
+Claude calls `get` with the exact name and `includePropertyDetails: true` so the response includes each attached property's type, constraints, and allowed values. Useful when the agent already knows the canonical name and wants the full schema in one call.
+
+```json
+{
+  "type": "event",
+  "name": "Account Created",
+  "includePropertyDetails": true
+}
+```
+
+#### Read what changed on a branch
+
+**Prompt:** *"What's on the `checkout-v2` branch — and can you show me the iOS code diff?"*
+
+Claude calls `get` with `type: "branch"` and combines `changes` and `code_snippets` in `include`. `sourceId` scopes the diff to a single source.
+
+```json
+{
+  "type": "branch",
+  "branchName": "checkout-v2",
+  "include": ["changes", "code_snippets"],
+  "sourceId": "src-ios"
+}
+```
+
+### Common errors
+
+- Item not found.
+- Ambiguous name (returns multiple matches — narrow by ID).
+- `sourceId` missing when `include` contains `code_snippets`.
+- Workspace access denied.
 
 ---
 
@@ -127,7 +196,9 @@ Find tracking plan items in one of two modes — the mode is selected automatica
 - **Semantic search** — pass `query` to find items by meaning across events, properties, metrics, categories, property bundles, and event variants. Uses vector similarity, not keyword matching — `"user signed up"` matches `Account Created` or `Registration Completed`.
 - **Structured listing** — omit `query` and pass filters to enumerate exact matches with keyset pagination.
 
-**Parameters shared across modes:**
+### Parameters
+
+**Shared across modes**
 
 | Parameter | Required | Description |
 |---|---|---|
@@ -135,7 +206,7 @@ Find tracking plan items in one of two modes — the mode is selected automatica
 | `maxResults` | No | Semantic mode: 1–20, default 10. Filter mode: 1–500, default 10. |
 | `workspaceId` | No | Workspace ID. |
 
-**Semantic mode** *(pass `query`)*:
+**Semantic mode** *(pass `query`)*
 
 | Parameter | Required | Description |
 |---|---|---|
@@ -143,7 +214,7 @@ Find tracking plan items in one of two modes — the mode is selected automatica
 
 Semantic search is performed against the **main branch** only. The semantic index may lag slightly for very recently created or updated items.
 
-**Filter mode** *(omit `query`, pass any of the filter fields)*:
+**Filter mode** *(omit `query`, pass any of the filter fields)*
 
 | Parameter | Required | Description |
 |---|---|---|
@@ -165,7 +236,13 @@ Semantic search is performed against the **main branch** only. The semantic inde
 
 Multiple values inside one array are OR'd; values across different filter keys are AND'd.
 
-**Returns:** Ranked results with rank, name, type, item ID, relevance percentage, and a truncated description (80 characters). Filter-mode responses include a `nextPageToken` when more results are available.
+<Callout type="info" emoji="🔒">
+  Semantic search requires Avo Intelligence Smart Search to be enabled in your workspace. Workspace admins can enable it in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). If you don't have admin access, ask a workspace admin to enable it. Filter-mode listing does not require Smart Search.
+</Callout>
+
+### Returns
+
+Ranked results with rank, name, type, item ID, relevance percentage, and a truncated description (80 characters). Filter-mode responses include a `nextPageToken` when more results are available.
 
 ```json
 {
@@ -190,9 +267,42 @@ Multiple values inside one array are OR'd; values across different filter keys a
 }
 ```
 
-<Callout type="info" emoji="🔒">
-  Semantic search requires Avo Intelligence Smart Search to be enabled in your workspace. Workspace admins can enable it in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). If you don't have admin access, ask a workspace admin to enable it. Filter-mode listing does not require Smart Search.
-</Callout>
+### Examples
+
+#### Find events by meaning (semantic)
+
+**Prompt:** *"What events do we have for signup?"*
+
+Claude passes the user's phrasing directly to `query`. Semantic mode returns events whose meaning matches the query, even when the exact words differ — `"user signed up"` will match `Account Created` or `Registration Completed`.
+
+```json
+{
+  "query": "user signed up",
+  "itemType": "event",
+  "maxResults": 5
+}
+```
+
+#### List events using a specific property (filter)
+
+**Prompt:** *"Which events on iOS use the `product_id` property?"*
+
+Filter mode is selected by omitting `query`. Multiple filter keys are AND'd, so this returns only events that reference `product_id` *and* are tracked from the `iOS` source.
+
+```json
+{
+  "itemType": "event",
+  "properties": ["product_id"],
+  "sources": ["iOS"],
+  "maxResults": 50
+}
+```
+
+### Common errors
+
+- `query` and structural filters combined — returns 400. Choose one mode.
+- Smart Search not enabled in the workspace — semantic mode fails; fall back to filter mode or `get`.
+- Workspace access denied.
 
 ---
 
@@ -209,7 +319,11 @@ Branch-lifecycle write operations. Currently supports two actions:
 - `create_branch` — open a new branch.
 - `update_branch_description` — set the description on an existing open branch.
 
-**Parameters:**
+<Callout type="info" emoji="💡">
+  A branch is a draft workspace for tracking-plan changes, analogous to a git branch. All write operations via the MCP happen on a branch — `save_items` requires a `branchId` that exists. The MCP never merges to main; open the branch in the Avo app to review and merge.
+</Callout>
+
+### Parameters
 
 | Parameter | Required | Description |
 |---|---|---|
@@ -219,13 +333,45 @@ Branch-lifecycle write operations. Currently supports two actions:
 | `description` | For `update_branch_description` | The new description text. |
 | `workspaceId` | No | Workspace ID |
 
-**Returns:** For `create_branch`: the new branch's `branchId`, `branchName`, and a `branchUrl` that opens it in the Avo web app. For `update_branch_description`: confirmation with the resolved `branchId` and the updated description.
+### Returns
 
-<Callout type="info" emoji="💡">
-  A branch is a draft workspace for tracking-plan changes, analogous to a git branch. All write operations via the MCP happen on a branch — `save_items` requires a `branchId` that exists. The MCP never merges to main; open the branch in the Avo app to review and merge.
-</Callout>
+For `create_branch`: the new branch's `branchId`, `branchName`, and a `branchUrl` that opens it in the Avo web app. For `update_branch_description`: confirmation with the resolved `branchId` and the updated description.
 
-**Common errors:** missing `write` scope (re-authorize with write), workspace access denied, unsupported action value, both `branchId` and `branchName` provided (`update_branch_description` requires exactly one).
+### Examples
+
+#### Create a branch for a new feature
+
+**Prompt:** *"Start an Avo branch for the new checkout flow we're shipping next sprint."*
+
+Claude calls `workflow` with `action: "create_branch"` and a descriptive `branchName`. The returned `branchId` is required for the follow-up `save_items` calls that write the new events and properties.
+
+```json
+{
+  "action": "create_branch",
+  "branchName": "add-checkout-tracking"
+}
+```
+
+#### Update a branch's description
+
+**Prompt:** *"Update the description on the `add-checkout-tracking` branch to mention that we're now also tracking abandonment."*
+
+Claude looks up the branch by name (no separate `branchId` lookup needed for this action) and replaces the description in one call.
+
+```json
+{
+  "action": "update_branch_description",
+  "branchName": "add-checkout-tracking",
+  "description": "Adds the Checkout Completed and Checkout Abandoned events with the Checkout Method property."
+}
+```
+
+### Common errors
+
+- Missing `write` scope — re-authorize with `write`.
+- Workspace access denied.
+- Unsupported action value.
+- Both `branchId` and `branchName` provided — `update_branch_description` requires exactly one.
 
 ---
 
@@ -239,7 +385,9 @@ Branch-lifecycle write operations. Currently supports two actions:
 
 Batch create, update, remove, and archive events, properties, event variants, property bundles, and metrics on a branch. A single call can mix item types and operations, and can cross-reference new items via temporary IDs.
 
-**Top-level parameters:**
+### Parameters
+
+**Top-level**
 
 | Parameter | Required | Description |
 |---|---|---|
@@ -404,7 +552,37 @@ To reference a newly-created item from another item in the same call, declare a 
 - `$tmp:` references are resolved in these array fields: `properties`, `addProperties`, `removeProperties`, `attachProperties`, `propertyBundles`, `addPropertyBundles`, `removePropertyBundles`, `attachToEvents`, `addSources`, `removeSources`, `bundleOverrides`; inside `overrides[].propertyId` / `addComponentOverrides[].propertyId`; and within nested metric fields (`items[].metricId` / `eventId` / `baseEventId`, `cohortConditions[].eventId` / `propertyId`). Source and destination IDs must be real IDs — `save_items` does not create those entity types.
 - If a `$tmp:` ref names a tempId that wasn't declared on any item, the server returns a validation error.
 
-### Example: create a new event with a new property in one call
+### Returns
+
+A structured result with:
+
+- `createdEntities`, `updatedEntities`, `removedEntities`, `archivedEntities` — each entry has `name`, `entityId`, and `entityType` (`event`, `property`, `event_variant`, `property_bundle`, or `metric`).
+- `errors` — per-item validation or audit errors, each with the item index, name, and a message.
+- `warnings` — non-fatal notices, same shape as errors.
+- `success` — overall boolean.
+
+```json
+{
+  "success": true,
+  "createdEntities": [
+    { "name": "Checkout Method", "entityId": "prop-9d44…", "entityType": "property" }
+  ],
+  "updatedEntities": [
+    { "name": "Checkout Completed", "entityId": "evt-3f01…", "entityType": "event" }
+  ],
+  "removedEntities": [],
+  "errors": [],
+  "warnings": []
+}
+```
+
+### Examples
+
+#### Create a new event with a new property in one call
+
+**Prompt:** *"Add a `Checkout Completed` event with a `Checkout Method` property for Web and iOS."*
+
+Claude declares a `tempId` on the new property so the new event can attach it before the server has allocated a real ID. The server resolves the `$tmp:` reference, allocates the real `propertyId`, attaches the property to the event, and includes the event in both sources — all atomically.
 
 ```json
 {
@@ -431,56 +609,39 @@ To reference a newly-created item from another item in the same call, declare a 
 }
 ```
 
-The server allocates a real ID for `checkout_method`, attaches the new property to the new `Checkout Completed` event, and includes the event in the `Web` and `iOS` sources — all atomically.
+#### Define a checkout funnel metric
 
-### Example: add allowed values to an existing property
+**Prompt:** *"Add a funnel metric on this branch that tracks the share of users who start checkout and complete it."*
+
+Claude creates a `Funnel` metric whose `items` reference two existing events in order. The same call could chain in new events with `$tmp:` references if the funnel needed events that don't exist yet.
 
 ```json
 {
   "branchId": "br-abc123",
   "items": [
     {
-      "op": "update",
-      "type": "property",
-      "propertyId": "prop-abc123",
-      "addAllowedValues": ["Buy Now", "Subscribe"]
+      "op": "create",
+      "type": "metric",
+      "name": "Checkout Funnel",
+      "description": "Share of users who start checkout and complete it.",
+      "metricType": "Funnel",
+      "items": [
+        { "eventId": "evt-checkout-started" },
+        { "eventId": "evt-checkout-completed" }
+      ]
     }
   ]
 }
 ```
 
-### Response
-
-Returns a structured result with:
-
-- `createdEntities`, `updatedEntities`, `removedEntities`, `archivedEntities` — each entry has `name`, `entityId`, and `entityType` (`event`, `property`, `event_variant`, `property_bundle`, or `metric`).
-- `errors` — per-item validation or audit errors, each with the item index, name, and a message.
-- `warnings` — non-fatal notices, same shape as errors.
-- `success` — overall boolean.
-
-```json
-{
-  "success": true,
-  "createdEntities": [
-    { "name": "Checkout Method", "entityId": "prop-9d44…", "entityType": "property" }
-  ],
-  "updatedEntities": [
-    { "name": "Checkout Completed", "entityId": "evt-3f01…", "entityType": "event" }
-  ],
-  "removedEntities": [],
-  "errors": [],
-  "warnings": []
-}
-```
-
-**Common errors:**
+### Common errors
 
 - Missing `write` scope — the client must re-authorize with `write`.
 - `branchId is required` / `items is required` — malformed request.
 - `tempId is only valid on create items` — don't set `tempId` on `update` or `remove`.
 - `Duplicate tempId "<name>"` — each `tempId` must be unique across items in the batch.
 - `Unknown $tmp: reference` — a `$tmp:` ref names a tempId that wasn't declared.
-- `<idField> is required for <op> <entity> items` — missing `eventId` / `propertyId` / `baseEventId` / `variantId`.
+- `<idField> is required for <op> <entity> items` — missing `eventId` / `propertyId` / `baseEventId` / `variantId` / `propertyBundleId` / `metricId`.
 - `too many items (got N, max 100)` — batch is over the 100-item cap.
 - `NotYetImplemented` — one of the unsupported operations above.
 - Per-item audit-pipeline validation failures (e.g. illegal name, duplicate property, etc.) — returned inside the `errors` array rather than failing the whole call.

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -2,42 +2,31 @@ import { Callout } from 'nextra/components'
 
 # Avo MCP tools reference
 
-Every tool except `health_check` and `list_workspaces` operates on a workspace. Pass `workspaceId` as a parameter; stdio clients can also set the `WORKSPACE_ID` environment variable.
+Every tool except `list_workspaces` operates on a workspace. Pass `workspaceId` as a parameter; stdio clients can also set the `WORKSPACE_ID` environment variable.
 
 <Callout type="info" emoji="🔒">
-  Tools are grouped below by capability. Each tool lists the OAuth scope required. Write tools (`workflow`, `save_items`) require the `write` scope, which is requested as a separate consent step on first use.
+  Tools are grouped below by intent. Each tool lists the OAuth scope required. Write tools (`workflow`, `save_items`) require the `write` scope, which is requested as a separate consent step on first use.
 </Callout>
 
-**Discovery & navigation**
-- [`health_check`](#health_check) — verify the server is up
+The MCP maps five canonical tools to agent intents:
+
+**Entry point**
 - [`list_workspaces`](#list_workspaces) — find your workspace IDs
-- [`list_branches`](#list_branches) — browse branches
-- [`get_sources`](#get_sources) — find source IDs for a workspace
 
-**Reading the plan**
-- [`get`](#get) — get item details by ID or exact name
-- [`search`](#search) — semantic similarity search
+**Discover** *(read)*
+- [`search`](#search) — find items by meaning or by structural filter
 
-**Reading a specific branch**
-- [`get_branch_details`](#get_branch_details) — full branch details (resolved emails, impacted sources, status)
-- [`get_branch_implementation_guide`](#get_branch_implementation_guide) — what changed on a branch
-- [`get_branch_code_snippets`](#get_branch_code_snippets) — per-event code diffs for a branch + source
+**Understand** *(read)*
+- [`get`](#get) — full details for any tracking plan item (or a branch overview / code snippets)
 
-**Writing (beta)**
-- [`workflow`](#workflow) — progress the plan forward (e.g. create a branch)
-- [`save_items`](#save_items) — create / update / remove events, properties, event variants on a branch
+**Change** *(write)*
+- [`save_items`](#save_items) — create, update, remove, or archive events, properties, event variants, property bundles, and metrics on a branch
 
----
+**Progress** *(write)*
+- [`workflow`](#workflow) — create a branch or update its description
 
-## `health_check`
-
-**Scope:** `read`
-
-Verify the MCP server is running and responsive.
-
-**Parameters:** None
-
-**Returns:** A simple `OK` status.
+**Transitional** *(read — kept while its replacement ships)*
+- [`list_branches`](#list_branches) — browse branches (planned: folded into `search(type:"branch")`)
 
 ---
 
@@ -58,6 +47,10 @@ Call this first to discover workspace IDs before invoking any workspace-scoped t
 ## `list_branches`
 
 **Scope:** `read`
+
+<Callout type="info" emoji="🚧">
+  **Transitional.** This tool stays available while branch enumeration is being folded into [`search`](#search) with `type: "branch"`. Until that ships, use `list_branches` to enumerate branches.
+</Callout>
 
 Browse branches in a workspace with filtering and pagination. Results are paginated newest-first.
 
@@ -80,7 +73,7 @@ Browse branches in a workspace with filtering and pagination. Results are pagina
 | `createdBefore` | No | ISO 8601 date — only branches created before |
 | `impactedSourceId` | No | Filter to branches affecting a specific source |
 
-**Returns:** Compact per-branch summary — name, status, ID, creator email — plus a `nextPageToken` when more results are available. Call `get_branch_details` for full resolved data.
+**Returns:** Compact per-branch summary — name, status, ID, creator email — plus a `nextPageToken` when more results are available. Call [`get`](#get) with `type: "branch"` and `include: ["overview"]` for full resolved data.
 
 <Callout type="info" emoji="💡">
   To find "my branches," pass your own email as `creatorEmail` or `reviewerEmail`. The tool does not auto-inject your identity into the filter.
@@ -92,123 +85,22 @@ By default `Merged` and `Closed` branches are excluded. Pass `branchStatuses: ["
 
 ---
 
-## `get_branch_details`
-
-**Scope:** `read`
-
-Full details for a specific branch.
-
-**Parameters:**
-
-| Parameter | Required | Description |
-|---|---|---|
-| `branchId` | One of `branchId` or `branchName` | Branch ID (takes precedence over name) |
-| `branchName` | One of `branchId` or `branchName` | Branch name — best-match, prioritizes open branches |
-| `workspaceId` | No | Workspace ID |
-
-**Returns:**
-- Resolved emails for the creator, all reviewers, and all collaborators
-- Branch status
-- Complete list of impacted source IDs
-- Branch description
-
-Use this after `list_branches` to drill into a specific branch.
-
-**Common errors:** branch not found, ambiguous branch name, workspace access denied.
-
----
-
-## `get_branch_implementation_guide`
-
-**Scope:** `read`
-
-High-level implementation guide for a branch — everything an implementer needs to understand what changed.
-
-**Parameters:**
-
-| Parameter | Required | Description |
-|---|---|---|
-| `branchId` | One of `branchId` or `branchName` | Branch ID |
-| `branchName` | One of `branchId` or `branchName` | Branch name |
-| `workspaceId` | No | Workspace ID |
-| `sourceId` | No | Filter to a specific source. Use `get_sources` to find source IDs. |
-
-**Returns:**
-
-- **Summary:** counts of new, modified, and deleted events
-- **New events:** name, description, property list, and whether the source uses Avo Codegen or manual implementation
-- **Modified events:** what changed (name, description, properties) with before/after values
-- **Deleted events:** name, description, properties
-- **Implementation steps:** instructions tailored to the source type (Codegen: check `avo.json`, run `avo pull`, import, implement, validate; Manual: what to add, change, or remove)
-
-When `sourceId` is provided, the guide filters to changes affecting only that source.
-
-**When to use this vs `get_branch_code_snippets`:** Use this tool to understand the *scope* of changes. Use `get_branch_code_snippets` when you need the actual code diffs to write implementation code.
-
----
-
-## `get_branch_code_snippets`
-
-**Scope:** `read`
-
-Per-event code snippets — unified diffs — for all changed events on a branch, for a specific source.
-
-**Parameters:**
-
-| Parameter | Required | Description |
-|---|---|---|
-| `sourceId` | Yes | Source ID. Use `get_sources` to find source IDs. |
-| `branchId` | One of `branchId` or `branchName` | Branch ID |
-| `branchName` | One of `branchId` or `branchName` | Branch name |
-| `workspaceId` | No | Workspace ID |
-
-**Returns:** Per-event implementation snippets, including:
-
-- **Event status:** New, Added (to source), Updated, Removed (from source), or Deleted
-- **Label:** `[Codegen]` or `[Pseudocode]` per event
-- **Diff:** exact unified diff between main and the branch for `[Codegen]` events; illustrative before/after for `[Pseudocode]` events
-- **Contextual guidance** per event (e.g., run `avo pull` for Codegen, implement manually for pseudocode, remove calls for deleted events)
-
-<Callout type="info" emoji="💡">
-  **Codegen vs pseudocode.** Avo sources can use Avo Codegen (type-safe generated code pulled via `avo pull`) or manual implementation (Avo provides pseudocode as reference). `[Codegen]` events include exact unified diffs; `[Pseudocode]` events provide illustrative guidance to help you write the implementation manually.
-</Callout>
-
----
-
-## `get_sources`
-
-**Scope:** `read`
-
-List sources in a workspace. Sources represent the different places in your codebase where tracking fires — for example, "iOS App", "Web App", or "Backend Service".
-
-**Parameters:**
-
-| Parameter | Required | Description |
-|---|---|---|
-| `workspaceId` | No | Workspace ID |
-| `branchId` | No | Branch ID. Defaults to the main branch. |
-| `branchName` | No | Branch name. Defaults to the main branch. |
-
-**Returns:** A table of sources — name, programming language, platform, filename hint, and source ID. Sources with no language or platform configured are flagged.
-
-Call this to find a `sourceId` before using `get_branch_implementation_guide` or `get_branch_code_snippets`.
-
----
-
 ## `get`
 
 **Scope:** `read`
 
-Universal item-details tool. Look up a single tracking plan item by ID or exact name. Defaults to the main branch.
+Universal item-details tool. Look up a single tracking plan item by ID or exact name, read a branch's overview and code snippets, or enumerate workspace-level entities. Defaults to the main branch.
 
 **Parameters:**
 
 | Parameter | Required | Description |
 |---|---|---|
-| `type` | Yes | Item type. One of: `event`, `property`, `metric`, `category`, `propertyBundle`, `source`, `destination`, `groupType`, `eventVariant`. |
-| `id` | One of `id` or `name` | The item's unique ID. |
-| `name` | One of `id` or `name` | Exact name match. May return multiple matches for ambiguous names (especially properties) — use `search` for fuzzy lookup. |
+| `type` | Yes | Item type. One of: `event`, `property`, `metric`, `category`, `propertyBundle`, `source`, `destination`, `groupType`, `eventVariant`, `branch`, `workspaceConfig`. |
+| `id` | Varies by type | The item's unique ID. Required for `event`, `property`, `metric`, `category`, `propertyBundle`, `eventVariant` unless `name` is provided. Optional for `source`/`destination`/`groupType` (omit both `id` and `name` to enumerate). Optional for `branch` (defaults to the active branch context if omitted). Not used by `workspaceConfig`. |
+| `name` | Varies by type | Exact name match. Alternative to `id` for most types. May return multiple matches for ambiguous names (especially properties) — use [`search`](#search) for fuzzy lookup. |
 | `variantId` | For `eventVariant` | The variant ID. Combined with `id` (the base event ID). |
+| `include` | For `branch` | Array of branch facets to return: `overview`, `changes`, `code_snippets`. Combine `changes` and `code_snippets` for an implementer-ready picture of the branch. |
+| `sourceId` | When `include` contains `code_snippets` | Source ID to scope the code snippets to. |
 | `branchId` | No | Branch to look up on. Defaults to main. `branchId` takes precedence over `branchName`. |
 | `branchName` | No | Alternative to `branchId`. |
 | `includePropertyDetails` | No | Events only. When `true`, includes full property definitions (type, constraints, allowed values). Defaults to `false`, which returns only property ID + name references. |
@@ -217,7 +109,12 @@ Universal item-details tool. Look up a single tracking plan item by ID or exact 
 
 **Returns:** Full details for the item, shaped per item type.
 
-**Common errors:** item not found, ambiguous name (returns multiple matches — narrow by ID), workspace access denied.
+- `type: "event" \| "property" \| "metric" \| "category" \| "propertyBundle" \| "eventVariant"` — the item's full definition.
+- `type: "source" \| "destination" \| "groupType"` — a single entity when `id`/`name` is provided, or a workspace-level list when both are omitted.
+- `type: "branch"` — branch facets requested via `include`. `overview` returns resolved emails for the creator, reviewers, and collaborators, branch status, impacted source IDs, and description. `changes` returns the structured diff (new, modified, and deleted events with their properties and descriptions). `code_snippets` returns per-event code diffs for the source named in `sourceId` — exact unified diffs for [Avo Codegen](/implementation/avo-codegen-overview) sources and illustrative pseudocode for manually-instrumented sources.
+- `type: "workspaceConfig"` — the workspace's event/property naming conventions and casing rules, plus custom field definitions and the list of recognized PII types. Use this before proposing new events or properties so names match the workspace's audit rules.
+
+**Common errors:** item not found, ambiguous name (returns multiple matches — narrow by ID), `sourceId` missing for `include: ["code_snippets"]`, workspace access denied.
 
 ---
 
@@ -225,23 +122,76 @@ Universal item-details tool. Look up a single tracking plan item by ID or exact 
 
 **Scope:** `read`
 
-Semantic similarity search across events, properties, metrics, categories, and property bundles. Uses vector similarity, not keyword matching — a query like `"user signed up"` will match `Account Created` or `Registration Completed` by meaning.
+Find tracking plan items in one of two modes — the mode is selected automatically by which parameters you pass. **Combining `query` with structural filters returns 400.** For ID-based lookups use [`get`](#get).
 
-**Parameters:**
+- **Semantic search** — pass `query` to find items by meaning across events, properties, metrics, categories, property bundles, and event variants. Uses vector similarity, not keyword matching — `"user signed up"` matches `Account Created` or `Registration Completed`.
+- **Structured listing** — omit `query` and pass filters to enumerate exact matches with keyset pagination.
+
+**Parameters shared across modes:**
 
 | Parameter | Required | Description |
 |---|---|---|
-| `query` | Yes | Natural language search query |
-| `workspaceId` | No | Workspace ID |
-| `itemType` | No | Filter by type: `event`, `property`, `metric`, `category`, or `propertyBundle` |
-| `maxResults` | No | Number of results (1–20, default 10) |
+| `itemType` | No | Filter by type: `event` (default), `property`, `metric`, `category`, `propertyBundle`, or `eventVariant`. |
+| `maxResults` | No | Semantic mode: 1–20, default 10. Filter mode: 1–500, default 10. |
+| `workspaceId` | No | Workspace ID. |
 
-**Returns:** Ranked results with rank, name, type, item ID, relevance percentage, and a truncated description (80 characters).
+**Semantic mode** *(pass `query`)*:
 
-Search is performed against the **main branch** only. There is a brief indexing lag for very recently created or updated items.
+| Parameter | Required | Description |
+|---|---|---|
+| `query` | Yes | Natural language search query. |
+
+Semantic search is performed against the **main branch** only. The semantic index may lag slightly for very recently created or updated items.
+
+**Filter mode** *(omit `query`, pass any of the filter fields)*:
+
+| Parameter | Required | Description |
+|---|---|---|
+| `tags` | No | Filter by tag. |
+| `categories` | No | Filter by category name. |
+| `sources` | No | Filter by source name. Does not apply to metrics. |
+| `eventNames` | No | Filter by event name. With `itemType: "property"`, returns properties on those events. |
+| `variantNames` | No | Filter by event variant name. |
+| `properties` | No | With `itemType: "event"`, returns events referencing any of these properties. |
+| `includeVariants` | No | With `itemType: "event"`, interleaves each event's variants in the result set. |
+| `stakeholders` | No | Filter by stakeholder. |
+| `owners` | No | Filter by owner. |
+| `destinations` | No | Filter by destination name. |
+| `type` | No | With `itemType: "event"`, filter by event type. |
+| `nameMapping` | No | Filter by destination-name-mapping. Tagged object: `{ kind: "any" }` (items with any mapping) or `{ kind: "matchesAny", names: [...], includeNoMapping?: bool }` (items whose mapped name is in `names`; with `includeNoMapping: true` items without a mapping rule also pass). Omitting `nameMapping` means no filter on mapping. |
+| `branchId` | No | Branch to enumerate on. Defaults to main. |
+| `branchName` | No | Alternative to `branchId`. |
+| `pageToken` | No | Pagination token from a previous response. |
+
+Multiple values inside one array are OR'd; values across different filter keys are AND'd.
+
+**Returns:** Ranked results with rank, name, type, item ID, relevance percentage, and a truncated description (80 characters). Filter-mode responses include a `nextPageToken` when more results are available.
+
+```json
+{
+  "results": [
+    {
+      "rank": 1,
+      "name": "Account Created",
+      "itemType": "event",
+      "itemId": "evt-9f2b…",
+      "relevance": 0.91,
+      "description": "Sent when a new account is successfully created."
+    },
+    {
+      "rank": 2,
+      "name": "Signup Started",
+      "itemType": "event",
+      "itemId": "evt-3c11…",
+      "relevance": 0.87,
+      "description": "Sent when the user opens the signup screen."
+    }
+  ]
+}
+```
 
 <Callout type="info" emoji="🔒">
-  Semantic search requires Avo Intelligence Smart Search to be enabled in your workspace. Workspace admins can enable it in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). If you don't have admin access, ask a workspace admin to enable it.
+  Semantic search requires Avo Intelligence Smart Search to be enabled in your workspace. Workspace admins can enable it in [Workspace Settings](https://www.avo.app/schemas/default?settings=general). If you don't have admin access, ask a workspace admin to enable it. Filter-mode listing does not require Smart Search.
 </Callout>
 
 ---
@@ -254,23 +204,28 @@ Search is performed against the **main branch** only. There is a brief indexing 
   Write access is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
 </Callout>
 
-Progress the tracking plan forward. Currently supports one action: creating a branch.
+Branch-lifecycle write operations. Currently supports two actions:
+
+- `create_branch` — open a new branch.
+- `update_branch_description` — set the description on an existing open branch.
 
 **Parameters:**
 
 | Parameter | Required | Description |
 |---|---|---|
-| `action` | Yes | The workflow action. Supported: `create_branch`. |
-| `branchName` | Yes | Name for the new branch. |
+| `action` | Yes | The workflow action. One of: `create_branch`, `update_branch_description`. |
+| `branchName` | For `create_branch`; alternative to `branchId` for `update_branch_description` | Name for the new branch (`create_branch`), or the existing branch's name (`update_branch_description`). |
+| `branchId` | Alternative to `branchName` for `update_branch_description` | ID of the existing branch to update. Provide exactly one of `branchId` or `branchName`. |
+| `description` | For `update_branch_description` | The new description text. |
 | `workspaceId` | No | Workspace ID |
 
-**Returns:** The new branch's `branchId`, `branchName`, and a `branchUrl` that opens it in the Avo web app.
+**Returns:** For `create_branch`: the new branch's `branchId`, `branchName`, and a `branchUrl` that opens it in the Avo web app. For `update_branch_description`: confirmation with the resolved `branchId` and the updated description.
 
 <Callout type="info" emoji="💡">
   A branch is a draft workspace for tracking-plan changes, analogous to a git branch. All write operations via the MCP happen on a branch — `save_items` requires a `branchId` that exists. The MCP never merges to main; open the branch in the Avo app to review and merge.
 </Callout>
 
-**Common errors:** missing `write` scope (re-authorize with write), workspace access denied, unsupported action value.
+**Common errors:** missing `write` scope (re-authorize with write), workspace access denied, unsupported action value, both `branchId` and `branchName` provided (`update_branch_description` requires exactly one).
 
 ---
 
@@ -282,14 +237,14 @@ Progress the tracking plan forward. Currently supports one action: creating a br
   Write access is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
 </Callout>
 
-Batch create, update, and remove events, properties, and event variants on a branch. A single call can mix item types and operations, and can cross-reference new items via temporary IDs.
+Batch create, update, remove, and archive events, properties, event variants, property bundles, and metrics on a branch. A single call can mix item types and operations, and can cross-reference new items via temporary IDs.
 
 **Top-level parameters:**
 
 | Parameter | Required | Description |
 |---|---|---|
-| `branchId` | Yes | The branch to write to. Get it from `workflow`/`create_branch` or `list_branches`. |
-| `items` | Yes | Array of items to apply. Each item is typed by its `type` field (`event`, `property`, or `event_variant`) and has an `op` (`create`, `update`, or `remove`, default `create`). |
+| `branchId` | Yes | The branch to write to. Get it from [`workflow`](#workflow) (`action: "create_branch"`). |
+| `items` | Yes | Array of items to apply. Each item is typed by its `type` field and has an `op` (default `create`). |
 | `workspaceId` | No | Workspace ID |
 
 The request is capped at **100 items** per call.
@@ -300,23 +255,36 @@ Every item shares these fields:
 
 | Field | Type | Notes |
 |---|---|---|
-| `op` | `"create"` \| `"update"` \| `"remove"` | Defaults to `"create"`. `remove` is not supported for `event_variant`. |
-| `type` | `"event"` \| `"property"` \| `"event_variant"` | Required. |
-| `name` | string | Required on `create` for events and properties. Cosmetic (optional and ignored on writes) for `event_variant` items. |
+| `op` | `"create"` \| `"update"` \| `"remove"` \| `"archive"` | Defaults to `"create"`. Not every op applies to every type — see "Supported ops" below. |
+| `type` | `"event"` \| `"property"` \| `"event_variant"` \| `"property_bundle"` \| `"metric"` | Required. |
+| `name` | string | Required on `create` for events, properties, property bundles, and metrics. Cosmetic on `event_variant` items and on `update`/`remove` of other types. |
 | `tempId` | string | **Create only.** Declares a temporary handle (e.g. `"prop1"`). Reference it elsewhere in the same call as `"$tmp:prop1"`. The server allocates a real ID and resolves all `$tmp:` references before writing. |
 | `eventId` | string | Required on `update` / `remove` of events. |
 | `propertyId` | string | Required on `update` / `remove` of properties. |
+| `propertyBundleId` | string | Required on `update` / `remove` of property bundles. |
+| `metricId` | string | Required on `update` / `archive` of metrics. |
 | `baseEventId` | string | Required for `event_variant` items — the parent event's ID. |
-| `variantId` | string | Required on `update` of `event_variant`. On `create`, provide either `variantId` directly or a `tempId` on the same item (the server resolves the `tempId` into `variantId`). |
+| `variantId` | string | Required on `update` of `event_variant`. On `create`, provide either `variantId` directly or a `tempId` on the same item. |
 | `nameSuffix` | string | Required on `create` of `event_variant` — suffix appended to the parent event name (e.g. `buy_now` produces `click / buy_now`). |
-| `description` | string | Create-only. Event / property description. |
+| `description` | string | Create-only. Event / property / bundle / metric description. |
+
+**Supported ops by type:**
+
+| Type | create | update | remove | archive |
+|---|:-:|:-:|:-:|:-:|
+| `event` | ✅ | ✅ | ❌ (see "Not yet implemented") | — |
+| `property` | ✅ | ✅ | ✅ (archives the property + cascades references) | — |
+| `event_variant` | ✅ | ✅ | ❌ (see "Not yet implemented") | — |
+| `property_bundle` | ✅ | ✅ | ✅ (archives the bundle) | — |
+| `metric` | ✅ | ✅ | — | ✅ |
 
 **Create-event fields:**
 
 | Field | Notes |
 |---|---|
 | `properties` | Array of property IDs (or `$tmp:` refs) to attach. |
-| `sources` | Array of source IDs to include the event in. Find source IDs with [`get_sources`](#get_sources). |
+| `propertyBundles` | Array of property bundle IDs (or `$tmp:` refs) to attach to the event. |
+| `sources` | Array of source IDs to include the event in. Find source IDs with [`get`](#get) (`type: "source"` with `id`/`name` omitted to enumerate). |
 
 **Create-property fields:**
 
@@ -324,6 +292,7 @@ Every item shares these fields:
 |---|---|
 | `propertyType` | `string`, `int`, `long`, `float`, `bool`, `object`, `any` (aliases like `integer`, `boolean`, `double` accepted). |
 | `sendAs` | `event`, `user`, or `system`. |
+| `eventConfigs` | *(optional)* Per-event/per-source property settings on a fresh property. On `create`, only `events: { kind: "allEvents" }` entries are accepted — per-event-scoped entries are rejected because the property isn't attached to any event yet. See "Per-event property settings (`eventConfigs`)" below. |
 
 **Create-event_variant fields:**
 
@@ -333,12 +302,28 @@ Every item shares these fields:
 | `overrides` | Component-level overrides. Each entry: `{ propertyId, pinned }` or `{ propertyId, allowed }`. `pinned` and `allowed` are mutually exclusive per override. |
 | `bundleOverrides` | Bundle IDs to attach to the variant as property bundles. |
 
+**Create-property_bundle fields:**
+
+| Field | Notes |
+|---|---|
+| `addProperties` | Property IDs (or `$tmp:` refs) to include in the bundle. |
+| `attachToEvents` | Event IDs (or `$tmp:` refs) the new bundle should be attached to. |
+
+**Create-metric fields:**
+
+| Field | Notes |
+|---|---|
+| `metricType` | Required. One of `Funnel`, `EventSegmentation`, `Proportion`, `Retention`, `CustomEvent`, `Cohort`. Immutable after create — archive and recreate to change. |
+| `items` | Required for non-cohort metrics. Array of metric items referencing events by `eventId` (or `$tmp:` ref), with optional `baseEventId` for event variants. |
+| `cohortConditions` | Required for `Cohort` metrics. Array of conditions referencing events by `eventId` (or `$tmp:` ref) and optional `propertyId`. |
+
 **Update-event fields:** _(require `eventId`)_
 
 | Field | Notes |
 |---|---|
 | `set.description` | New event description. |
 | `addProperties` / `removeProperties` | Property IDs (or `$tmp:` refs) to associate / disassociate. |
+| `addPropertyBundles` / `removePropertyBundles` | Property bundle IDs (or `$tmp:` refs) to attach / detach. |
 | `addSources` / `removeSources` | Source IDs to include / exclude. |
 
 **Update-event_variant fields:** _(require `baseEventId` + `variantId`)_
@@ -359,28 +344,64 @@ Every item shares these fields:
 | `set.propertyType` | New type. Same value set as create: `string`, `int`, `long`, `float`, `bool`, `object`, `any` (aliases like `integer`, `boolean`, `double` accepted). |
 | `addAllowedValues` | **Top-level on the item, not inside `set`.** String values to add to a string-typed property's allowed list. |
 | `removeAllowedValues` | **Top-level on the item, not inside `set`.** Values not in the current list are silently no-ops. |
+| `eventConfigs` | **Top-level on the item.** Per-event/per-source property settings — change presence, pin a value, or restrict allowed values per event. See "Per-event property settings (`eventConfigs`)" below. |
+
+**Update-property_bundle fields:** _(require `propertyBundleId`)_
+
+| Field | Notes |
+|---|---|
+| `set.name` | Rename the bundle. |
+| `set.description` | New bundle description. |
+| `addProperties` / `removeProperties` | Property IDs (or `$tmp:` refs) to add / remove from the bundle. Bundle-to-event attachment is managed from the event side via `addPropertyBundles` / `removePropertyBundles` on event-update items. |
+
+**Update-metric fields:** _(require `metricId`)_
+
+| Field | Notes |
+|---|---|
+| `setName` | Rename the metric. |
+| `setDescription` | New metric description. |
+| `addItems` / `removeItems` | For non-cohort metrics, add or remove metric items. |
+| `addCohortConditions` / `updateCohortConditions` / `removeCohortConditions` | For `Cohort` metrics, manage the cohort condition list. |
 
 **Remove-property:** _(require `propertyId`)_
 
-`{ op: "remove", type: "property", propertyId: "..." }` archives the property on the branch and cascades a `RemovePropertyRefV3` action for every event that references it, mirroring the Avo UI. The action is destructive but reversible from the Avo app. If you only have the property name, look up the ID first with [`get`](#get) or [`search`](#search) so that any name-conflict ambiguity is surfaced before the mutation runs.
+`{ op: "remove", type: "property", propertyId: "..." }` archives the property on the branch and cascades removal references on every event that uses it, mirroring the Avo UI. The action is destructive but reversible from the Avo app. If you only have the property name, look up the ID first with [`get`](#get) or [`search`](#search) so that any name-conflict ambiguity is surfaced before the mutation runs.
+
+**Remove-property_bundle:** _(require `propertyBundleId`)_
+
+`{ op: "remove", type: "property_bundle", propertyBundleId: "..." }` archives the bundle on the branch.
+
+**Archive-metric:** _(require `metricId`)_
+
+`{ op: "archive", type: "metric", metricId: "..." }` archives the metric on the branch.
+
+### Per-event property settings (`eventConfigs`)
+
+`eventConfigs` is a top-level array on an `update`-property item (and, restricted to `events: { kind: "allEvents" }`, on a `create`-property item). Each entry adjusts how the property behaves on a specific event or across all events:
+
+- **`setPresence`** — change presence to `alwaysSent`, `sometimesSent`, or `neverSent`. Can be scoped per source.
+- **`setPinnedValue`** — pin a value for the property. With `events: { kind: "onEvent" }` pins per-event; with `events: { kind: "allEvents" }` pins property-wide.
+- **`restrictAllowedValues`** — change the property's allowed value list for an event. Carries a `valuesChange` delta: `addValues` (non-empty), `removeValues`, or `clear` (no payload).
+
+`eventConfigs` entries reference pre-existing events — a same-batch `create`-event item isn't visible to `eventConfigs` yet, so create the event in an earlier call (or the same batch, ordered before the property update that references it).
 
 <Callout type="warning" emoji="🚧">
   **Not yet implemented.** The following return a `NotYetImplemented` error from the server:
 
-  - `op: "remove"` on `event` items
+  - `op: "remove"` on `event` items (archiving events)
   - `op: "remove"` on `event_variant` items
   - `set.sendAs` on `op: "update"` of `property` items — `sendAs` is immutable after create
 
-  Everything else (create events / properties / event-variants; update events and event-variants; update a property's `description`, `propertyType`, or allowed values; remove a property) works today.
+  Everything else works today: create / update events, properties, event variants, property bundles, metrics; archive properties, bundles, metrics; per-event property settings via `eventConfigs`.
 </Callout>
 
 ### Temporary IDs (`tempId` / `$tmp:`)
 
 To reference a newly-created item from another item in the same call, declare a `tempId` on the `create` item and reference it elsewhere as `"$tmp:<name>"`:
 
-- `tempId` is **create-only** — setting it on an `update` or `remove` returns an error.
+- `tempId` is **create-only** — setting it on an `update`, `remove`, or `archive` returns an error.
 - `tempId` names must be unique within a single `save_items` call.
-- `$tmp:` references are resolved in these array fields: `properties`, `addProperties`, `removeProperties`, `attachProperties`, and inside `overrides[].propertyId` / `addComponentOverrides[].propertyId`. Source, destination, and bundle IDs cannot be `$tmp:` refs — they must be real IDs, since `save_items` does not create those entity types.
+- `$tmp:` references are resolved in these array fields: `properties`, `addProperties`, `removeProperties`, `attachProperties`, `propertyBundles`, `addPropertyBundles`, `removePropertyBundles`, `attachToEvents`, `addSources`, `removeSources`, `bundleOverrides`; inside `overrides[].propertyId` / `addComponentOverrides[].propertyId`; and within nested metric fields (`items[].metricId` / `eventId` / `baseEventId`, `cohortConditions[].eventId` / `propertyId`). Source and destination IDs must be real IDs — `save_items` does not create those entity types.
 - If a `$tmp:` ref names a tempId that wasn't declared on any item, the server returns a validation error.
 
 ### Example: create a new event with a new property in one call
@@ -432,10 +453,25 @@ The server allocates a real ID for `checkout_method`, attaches the new property 
 
 Returns a structured result with:
 
-- `createdEntities`, `updatedEntities`, `removedEntities` — each entry has `name`, `entityId`, and `entityType` (`event`, `property`, or `event_variant`).
+- `createdEntities`, `updatedEntities`, `removedEntities`, `archivedEntities` — each entry has `name`, `entityId`, and `entityType` (`event`, `property`, `event_variant`, `property_bundle`, or `metric`).
 - `errors` — per-item validation or audit errors, each with the item index, name, and a message.
 - `warnings` — non-fatal notices, same shape as errors.
 - `success` — overall boolean.
+
+```json
+{
+  "success": true,
+  "createdEntities": [
+    { "name": "Checkout Method", "entityId": "prop-9d44…", "entityType": "property" }
+  ],
+  "updatedEntities": [
+    { "name": "Checkout Completed", "entityId": "evt-3f01…", "entityType": "event" }
+  ],
+  "removedEntities": [],
+  "errors": [],
+  "warnings": []
+}
+```
 
 **Common errors:**
 

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -1,3 +1,8 @@
+---
+title: Avo MCP tools reference
+description: Reference for the five canonical Avo MCP tools (list_workspaces, search, get, save_items, workflow) plus parameter shapes, return schemas, and per-tool examples with natural-language prompts.
+---
+
 import { Callout } from 'nextra/components'
 
 # Avo MCP tools reference
@@ -254,6 +259,17 @@ Claude calls `get` with `type: "branch"` and combines `changes` and `code_snippe
 </Callout>
 
 Batch create, update, remove, and archive events, properties, event variants, property bundles, and metrics on a branch. A single call can mix item types and operations, and can cross-reference new items via temporary IDs.
+
+<Callout type="info" emoji="💡">
+  **Quick reference.** Common patterns:
+
+  - **Create an event with new properties** — pair `create-event` and `create-property` items in one batch, using `tempId` to cross-reference.
+  - **Add allowed values to a property** — `update-property` with top-level `addAllowedValues`.
+  - **Rename an event or property** — `update-event` / `update-property` with `set.name`.
+  - **Archive an event** — `op: "archive"` (or legacy `op: "remove"`).
+  - **Create a funnel metric** — `create-metric` with `metricType: "Funnel"` and `items`.
+  - **Toggle a property between scalar and list** — `update-property` with top-level `isList: true` / `false`.
+</Callout>
 
 ### Parameters
 

--- a/pages/reference/avo-mcp/tools.mdx
+++ b/pages/reference/avo-mcp/tools.mdx
@@ -252,10 +252,14 @@ Claude calls `get` with `type: "branch"` and combines `changes` and `code_snippe
 
 ## `save_items`
 
-**Scope:** `write`
+**Scope:** `write` · **Destructive:** archive / remove ops
 
 <Callout type="info" emoji="🚧">
   Write access is in general beta — enabled for every workspace, no need to request access. [Email support@avo.app](mailto:support@avo.app) if you hit anything unexpected.
+</Callout>
+
+<Callout type="warning" emoji="⚠️">
+  **Destructive operations.** `op: "archive"` on events and metrics, and `op: "remove"` on properties and property bundles, archive the target item on the branch. Property archives cascade — references on every event that uses the property are also removed. All archives are reversible from the Avo web app, but the cascade means a single call can touch many events.
 </Callout>
 
 Batch create, update, remove, and archive events, properties, event variants, property bundles, and metrics on a branch. A single call can mix item types and operations, and can cross-reference new items via temporary IDs.


### PR DESCRIPTION
## Why

This PR prepares the Avo MCP overview and tools reference for submission to the [Claude AI catalog](https://claude.com/docs/connectors/building/submission). Two drivers shaped every change:

1. **Catalog submission compliance** — meet every requirement in the [Anthropic Software Directory Policy](https://support.claude.com/en/articles/13145358-anthropic-software-directory-policy) and the [official submission guide](https://claude.com/docs/connectors/building/submission) so the listing passes review.
2. **GEO (Generative Engine Optimization)** — make the docs structured, citable, and self-contained so AI summarizers, retrieval-augmented assistants, and search engines can pull accurate snippets directly.

Closes [AVO-2879](https://linear.app/avo/issue/AVO-2879/polish-mcp-docs-page-with-example-dialogue-sample-responses).

## Catalog compliance

| Requirement | How this PR addresses it |
|---|---|
| §3.A Privacy policy link + summary | "Support and privacy" section with a four-bullet privacy summary (collection / use / storage / third-party sharing) and a link to the full policy |
| §3.B Verified support channel | `support@avo.app` surfaced in the support section |
| §3.C Document how it works + troubleshooting | Three named Use cases + Troubleshooting split across both pages (auth/access on overview, tool-specific behavior on tools.mdx, cross-linked) |
| §3.E Three working examples (prompts OR use cases) | Three named Use cases each with a natural-language prompt, plus four "Other example flows" bullets |
| §5.D OAuth 2.0 | Full Authentication section + first-call OAuth Callout at the top of Setup |
| §5.E Destructive tool indicators | `save_items` header line + warning Callout listing which ops are destructive and that property archives cascade |
| Submission guide: clear setup and usage instructions | Per-client setup snippets (Claude Code, Claude Desktop, Cursor, generic) |
| Submission form: documentation link, tagline, use cases | Public docs URL, entity-first lead sentence, explicit "Use cases" heading |

## GEO improvements

- **Frontmatter** (`title` + `description`) on both pages for raw-MDX crawlers.
- **Question-form FAQ** (five common queries) — question headings rank well in AI summaries because they match user queries verbatim. Positioned above Setup so pre-installation questions get answered first.
- **Consistent section outline** across every tool: Parameters / Returns / Examples / Common errors. Each tool has 1–2 examples framed as a prompt plus the resulting tool call.
- **Capability matrix** mapping tools to agent intents (Entry / Discover / Understand / Change / Progress) — both on the overview and at the top of the tools reference.
- **Concrete natural-language prompts in every example** — *"what events do we have for signup?"*, *"Add a `Checkout Completed` event with a `Checkout Method` property for Web and iOS."*
- **Self-contained sections with anchor links** between the two pages so a reader can jump from a workflow to its tool reference or from a troubleshooting entry to the corresponding tool.
- **Acronym expansion** with a link to modelcontextprotocol.io on first mention.
- **Limits section** so engines can answer operational questions accurately (batch caps, result caps, pagination).

## Final overview h2 order

```
Use cases (with three workflow h3s + Other example flows)
Capability matrix
Limits
FAQ
Setup
Authentication
Troubleshooting (auth + access only — tool-specific is on tools.mdx)
Support and privacy (with Privacy summary)
```

## Tools reference

- **Remove** deprecated tools whose functionality has moved into `get` / `search`: `health_check`, `get_sources`, `get_branch_details`, `get_branch_code_snippets`, `get_branch_implementation_guide`. `list_branches` stays as a transitional tool until `search(type:"branch")` ships.
- **Reorder** sections to match the canonical surface order returned by `tools/list` (`list_workspaces` → `search` → `get` → `save_items` → `workflow` → `list_branches`).
- **Standardize** section structure across every tool: Parameters / Returns / Examples / Common errors, with 1–2 examples per tool framed as a natural-language prompt plus the resulting tool call.
- **`get`** documents the `branch` type with the `include` axis (`overview` / `changes` / `code_snippets`, defaults to `["overview"]`), source/destination/groupType enumeration when both `id` and `name` are omitted, and the expanded `workspaceConfig` (custom-field + PII type lists).
- **`search`** documents both modes (semantic and filter), every filter parameter including `customField` and `pii`, pagination, the 400 returned when `query` and filters are combined, and the Smart Search prerequisite as a callout directly under the mode bullets. Semantic search now mentions the OpenAI-embedding + vector-similarity mechanism.
- **`save_items`** documents `property_bundle`, `metric`, and `category` item types, all four ops (`create` / `update` / `remove` / `archive`), per-event property settings via `eventConfigs`, `addPropertyBundles` / `removePropertyBundles`, `addCategories` / `removeCategories` (note: by name, not ID), `tags` / `addTags` / `removeTags`, `set.name` for renames, top-level `isList` toggle, `nameMappings` (tagged-object shape), the full variant override surface (3-state add/remove/clear lattice across attached properties, source overrides, bundle overrides, variant property regex overrides) plus `set.triggers`, and the updated `NotYetImplemented` list. A Quick reference Callout at the top lists the six most common ops. **Owner and stakeholder** fields get their own subsection with a `⚠️` Branch-independent warning — these mutations take effect workspace-wide and do **not** roll back if the branch is discarded. **Merging categories** has its own subsection explaining the no-merge-op recipe.
- **`workflow`** documents the new `update_branch_description` action.
- Canonical sample JSON responses next to `search` and `save_items`.
- `save_items` batch cap corrected to **50 items per call** (was previously documented as 100).

## Review feedback addressed

- **CodeRabbit** (`tools.mdx:435`) — clarified `eventConfigs` event-reference constraints; the previous wording contradicted the `$tmp:` resolution list. Now states explicitly that `eventConfigs` can only reference events from earlier `save_items` calls. (Commit `ddf6e68c`.)
- **bjornj12** (`overview.mdx:78`) — enumerated the full tracking-plan item set in the data-collection FAQ entry instead of trailing off with "etc". (Commit `6710d4ec`.)
- **bjornj12** (`tools.mdx:73`) — added the implementation detail Björn provided: Avo embeds items with OpenAI embeddings and runs vector-similarity search at query time; Smart Search prerequisite promoted to a callout under the mode bullets. (Commits `6710d4ec` + `24182a66`.)

## Test plan

- [ ] Review the rendered overview page end-to-end — three Use cases read cleanly, FAQ answers are accurate, Troubleshooting entries fire correctly, Support and privacy section points at the right URLs (`support@avo.app`, `https://www.avo.app/l/privacy`).
- [ ] Verify each Setup snippet works as documented in its respective client.
- [ ] Spot-check the tools reference: capability matrix, `get`'s branch facets, `search` filter mode + Smart Search callout, `save_items` `category` and `event_variant` archive support, owner/stakeholder branch-independent warning, variant override lattice, `addCategories`/`removeCategories` on event/property/metric updates, `nameMappings` shape, the corrected 50-item batch cap.
- [ ] Confirm no lingering references to the five removed tools outside of git history.
- [ ] Spellcheck passes (`yarn spellcheck`).
- [ ] Side-by-side compare the overview's capability matrix link targets against the `tools.mdx` anchor IDs.

## Notes for MCP owners

- `projects/mcp/src/tools/GetItemDetails.res:1116` advertises `include: ["details", "code_snippets"]` in a source-listing hint, but the include enum only has `overview | changes | code_snippets`. This PR documents the canonical enum values; fixing the hint string is owner work.
- The briefing referenced `ListWorkspaces_description.res` and `GetItemDetails_description.res` as colocated description files, but those files don't yet exist in the monorepo. Description text for those tools is currently inline (`let description = ...`) in their `.res` files. Worth confirming the colocated files were intended to ship alongside.
- The gap analysis fixes in commit `abb0971e` documented several fields (exact form of stakeholder references, `nameMappings` verb on update, full variant override field list) using the names and shapes from the analysis. These weren't visible in the snapshot of `SaveItems_description.res` accessible from this worktree, so worth cross-checking against the current schema during review — the docs may need a touch-up if any field names drifted between the gap analysis and the current code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)