### PR TITLE
Add context7.json to claim the library on Context7

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,6 @@
 {
   "url": "https://context7.com/avohq/docs",
-  "public_key": "pk_349VfKnBMKZQlvoBl3xDy"
+  "public_key": "pk_349VfKnBMKZQlvoBl3xDy",
+  "projectTitle": "Avo",
+  "description": "Avo documentation — implement, validate, and manage analytics tracking with Avo's tracking plan workflows, Codegen, Inspector, and integrations."
 }

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/avohq/docs",
+  "public_key": "pk_349VfKnBMKZQlvoBl3xDy"
+}


### PR DESCRIPTION
Adds `context7.json` to the repository root with the URL and public key from the Context7 "Claim Library" dialog, so we can verify ownership of https://context7.com/avohq/docs.

Once this is merged to main, click "Claim Library" in the Context7 dialog to complete verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new configuration settings to support system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->