### PR TITLE
Use the published Avo MCP skill names in the AI-agents adoption docs

### DIFF
--- a/pages/adopting-avo-with-ai-agents/governing-ai-generated-analytics.mdx
+++ b/pages/adopting-avo-with-ai-agents/governing-ai-generated-analytics.mdx
@@ -59,7 +59,7 @@ Even a well-designed plan can go wrong in implementation: misnamed events, missi
 
 ## Give your agent the tracking-plan skill
 
-Once your plan is in Avo, the **[`avo-mcp`](https://github.com/avohq/avo-mcp-skills)** skill is the most direct way to keep your agent from drifting off it. It's an [Agent Skill](https://docs.claude.com/en/docs/claude-code/skills) that teaches your agent to work *within* your plan through the Avo MCP: look up and reuse existing events, properties, and metrics; design tracking for a new feature against what already exists; and propose changes on a branch instead of inventing new, inconsistent tracking.
+Once your plan is in Avo, the **[`data-designer`](https://github.com/avohq/avo-mcp)** skill is the most direct way to keep your agent from drifting off it. It's an [Agent Skill](https://docs.claude.com/en/docs/claude-code/skills) that teaches your agent to work *within* your plan through the Avo MCP: look up and reuse existing events, properties, and metrics; design tracking for a new feature against what already exists; and propose changes on a branch instead of inventing new, inconsistent tracking.
 
 - **It reuses before it creates.** The skill searches the plan for an existing event or property before proposing a new one — preventing duplicates at the source.
 - **It follows your rules.** Proposals are shaped by your audit rules, so names and structure match your conventions.
@@ -71,7 +71,7 @@ Once your plan is in Avo, the **[`avo-mcp`](https://github.com/avohq/avo-mcp-ski
 If your plan isn't in Avo yet, getting it there is quick:
 
 1. **Create a workspace** via the [Avo onboarding flow](https://avo.app/onboarding).
-2. **Import your existing tracking plan — the fastest way is through the Avo MCP.** With the [Avo MCP](/reference/avo-mcp/overview) connected and the **`avo-mcp`** skill added, ask your agent to import your plan from wherever it lives today — a spreadsheet, another tool, or an analytics platform like Amplitude or Mixpanel. Prefer to do it by hand? You can also [import it in the Avo web app](/publishing/import/get-tracking-plan-into-avo) once the workspace exists.
+2. **Import your existing tracking plan — the fastest way is through the Avo MCP.** With the [Avo MCP](/reference/avo-mcp/overview) connected and the **`data-designer`** skill added, ask your agent to import your plan from wherever it lives today — a spreadsheet, another tool, or an analytics platform like Amplitude or Mixpanel. Prefer to do it by hand? You can also [import it in the Avo web app](/publishing/import/get-tracking-plan-into-avo) once the workspace exists.
 
 From there everything is the same whether you imported a minute ago or have been on Avo for years: your agent designs within the plan — governed by your audit rules and implemented from generated code, on a branch you approve.
 

--- a/pages/adopting-avo-with-ai-agents/index.mdx
+++ b/pages/adopting-avo-with-ai-agents/index.mdx
@@ -11,26 +11,26 @@ When you use an AI coding agent — Claude Code, Cursor, Codex, and others — t
 
 Avo gives that work a governed home. Your agent connects through the [Avo MCP](/reference/avo-mcp/overview) and proposes changes against a shared tracking plan with audit rules; every change lands on a branch — never on main — and merging stays a deliberate human step in the Avo web app. Avo governs **both** sides of what your agent generates: the design (what's tracked, named to your conventions, without duplicates) and the implementation (code that matches the plan).
 
-Two [Avo MCP Agent Skills](https://github.com/avohq/avo-mcp-skills) teach your agent to do this well — one for starting from scratch, one for working within a plan you already have. Pick the page that matches your situation:
+Two [Avo MCP Agent Skills](https://github.com/avohq/avo-mcp) teach your agent to do this well — one for starting from scratch, one for working within a plan you already have. Pick the page that matches your situation:
 
 <TwoCol>
   <PageLink
     image="/docs/images/svg/dev.svg"
     title="Setting up a tracking plan for AI-generated analytics"
-    description="Starting fresh, with no tracking plan yet: the safe, incremental path to install the Avo MCP, bootstrap a best-practice plan, and open your first branch. Governs both the design and the implementation, with the avo-mcp-new-tracking-plan skill."
+    description="Starting fresh, with no tracking plan yet: the safe, incremental path to install the Avo MCP, bootstrap a best-practice plan, and open your first branch. Governs both the design and the implementation, with the data-designer-new-plan skill."
     href="/adopting-avo-with-ai-agents/setting-up-a-tracking-plan"
   />
   <PageLink
     image="/docs/images/svg/analyticsmanager.svg"
     title="Governing AI-generated analytics with your tracking plan"
-    description="Already have a tracking plan — in a spreadsheet, another tool, or Avo — that's ungoverned or disconnected from your code? How Avo governs it, connects it to implementation, and keeps your agent designing within it. Covers both the design and the implementation, with the avo-mcp skill."
+    description="Already have a tracking plan — in a spreadsheet, another tool, or Avo — that's ungoverned or disconnected from your code? How Avo governs it, connects it to implementation, and keeps your agent designing within it. Covers both the design and the implementation, with the data-designer skill."
     href="/adopting-avo-with-ai-agents/governing-ai-generated-analytics"
   />
 </TwoCol>
 
 ## Related
 
-- [Avo MCP Agent Skills](https://github.com/avohq/avo-mcp-skills) — the `avo-mcp` and `avo-mcp-new-tracking-plan` skills that guide your agent through the Avo MCP.
+- [Avo MCP Agent Skills](https://github.com/avohq/avo-mcp) — the `data-designer` and `data-designer-new-plan` skills that guide your agent through the Avo MCP.
 - [Agentic data design](/data-design/guides/agentic-data-design) — Avo's in-app AI suggestions for designing tracking.
 - [What is a Tracking Plan?](/data-design) — the governance model Avo enforces.
 - [Avo MCP overview](/reference/avo-mcp/overview) — setup, tools, OAuth, and the branch-write guarantee in full.

--- a/pages/adopting-avo-with-ai-agents/setting-up-a-tracking-plan.mdx
+++ b/pages/adopting-avo-with-ai-agents/setting-up-a-tracking-plan.mdx
@@ -1,6 +1,6 @@
 ---
 title: Setting up a tracking plan for AI-generated analytics
-description: Avo is safe to add to a project whether it already has analytics or none yet — it works alongside your current setup and never changes anything without review. Every change lands on a branch, never on main, and merging is a human step. The safe, incremental path is to connect the Avo MCP, open your first branch, or bootstrap a best-practice plan with the avo-mcp-new-tracking-plan skill.
+description: Avo is safe to add to a project whether it already has analytics or none yet — it works alongside your current setup and never changes anything without review. Every change lands on a branch, never on main, and merging is a human step. The safe, incremental path is to connect the Avo MCP, open your first branch, or bootstrap a best-practice plan with the data-designer-new-plan skill.
 ---
 
 import { Callout } from 'nextra/components'
@@ -47,7 +47,7 @@ You can go from zero to a reviewable branch in three steps:
 
 ## Start from a best-practice plan
 
-You don't have to design a plan from a blank page. Avo publishes the **[`avo-mcp-new-tracking-plan`](https://github.com/avohq/avo-mcp-skills)** skill, an [Agent Skill](https://docs.claude.com/en/docs/claude-code/skills) that walks your agent through bootstrapping one: a short purpose meeting (problems, goals, key funnels), an agreed naming convention, and a first set of `start → milestone → complete` events with their properties and constraints — then a branch for you to review.
+You don't have to design a plan from a blank page. Avo publishes the **[`data-designer-new-plan`](https://github.com/avohq/avo-mcp)** skill, an [Agent Skill](https://docs.claude.com/en/docs/claude-code/skills) that walks your agent through bootstrapping one: a short purpose meeting (problems, goals, key funnels), an agreed naming convention, and a first set of `start → milestone → complete` events with their properties and constraints — then a branch for you to review.
 
 - **It's a starting point, not a finished plan.** Review and adjust what it proposes before you merge.
 - **It goes through the same guardrail.** Everything the skill proposes is written to a branch, checked against your audit rules, and merged only when you approve — nothing reaches main automatically.


### PR DESCRIPTION
## What changed?

The new "Adopting Avo with AI agents" docs (#1709) referenced the Avo MCP Agent Skills by draft names that don't match what shipped in [avohq/avo-mcp](https://github.com/avohq/avo-mcp). This corrects all references across the three pages:

- `avo-mcp` skill → **`data-designer`** (work within an existing tracking plan)
- `avo-mcp-new-tracking-plan` skill → **`data-designer-new-plan`** (bootstrap a plan from scratch)
- `github.com/avohq/avo-mcp-skills` → `github.com/avohq/avo-mcp` (the repo was renamed; the old URL only works via redirect)

Names verified against the `skills/` directory and README of the avo-mcp repo.

## How to test this PR:

- Check the `name:` frontmatter in [skills/data-designer/SKILL.md](https://github.com/avohq/avo-mcp/blob/main/skills/data-designer/SKILL.md) and [skills/data-designer-new-plan/SKILL.md](https://github.com/avohq/avo-mcp/blob/main/skills/data-designer-new-plan/SKILL.md) and confirm the docs now match.
- `grep -rn "avo-mcp-skills\|avo-mcp-new-tracking-plan" pages` returns nothing.
- Spellcheck passes and the frontmatter on all three pages parses (only one frontmatter description was touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated references to AI agent skills in Avo MCP documentation to reflect current naming conventions for the `data-designer` skills.
  * Revised guidance for importing existing tracking plans and setting up new tracking plans when using Avo's AI agent capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->