### PR TITLE
security(deps): pin picomatch + minimatch to patched versions (AVO-3258, PR 3 of 3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,17 @@
     "tmp": "0.2.6",
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
-    "flatted": "3.4.2"
+    "flatted": "3.4.2",
+    "**/eslint/minimatch": "3.1.4",
+    "**/@eslint/eslintrc/minimatch": "3.1.4",
+    "**/@humanwhocodes/config-array/minimatch": "3.1.4",
+    "**/eslint-plugin-import/minimatch": "3.1.4",
+    "**/eslint-plugin-jsx-a11y/minimatch": "3.1.4",
+    "**/eslint-plugin-react/minimatch": "3.1.4",
+    "**/glob/minimatch": "3.1.4",
+    "**/ignore-walk/minimatch": "5.1.8",
+    "**/avo/minimatch": "7.4.8",
+    "**/@typescript-eslint/typescript-estree/minimatch": "9.0.9",
+    "**/micromatch/picomatch": "2.3.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2039,6 +2039,13 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
+brace-expansion@^2.0.2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
+  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
@@ -5907,33 +5914,33 @@ mimic-response@^4.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-4.0.0.tgz#35468b19e7c75d10f5165ea25e75a5ceea7cf70f"
   integrity sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==
 
-minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+minimatch@3.1.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.4.tgz#89d910ea3970a77ac8edfd30340ccd038b758079"
+  integrity sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
-  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+minimatch@5.1.8, minimatch@^5.0.1:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.8.tgz#32a16ebcccd6421c674430acb199b8806c68169b"
+  integrity sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^7.0.0:
-  version "7.4.6"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-7.4.6.tgz#845d6f254d8f4a5e4fd6baf44d5f10c8448365fb"
-  integrity sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==
+minimatch@7.4.8, minimatch@^7.0.0:
+  version "7.4.8"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-7.4.8.tgz#02e0e6de33a98f18922e13aa8a6d0980ffc5302d"
+  integrity sha512-RF6JWsI+7ecN51cfjtARMkIQoJxVeo3MIPKebcjf3J+mvrsbEHuHIDnPmu3FivgmWtTSsZI29wFH5TGeyqWC0g==
   dependencies:
-    brace-expansion "^2.0.1"
+    brace-expansion "^2.0.2"
 
-minimatch@^9.0.4:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
-  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
+minimatch@9.0.9, minimatch@^9.0.4:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
   dependencies:
-    brace-expansion "^2.0.1"
+    brace-expansion "^2.0.2"
 
 minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.8"
@@ -6472,10 +6479,10 @@ picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+picomatch@2.3.2, picomatch@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 picomatch@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## What & why

Follow-up to [AVO-3258](https://linear.app/avo/issue/AVO-3258) clearing the **`picomatch` + `minimatch`** alerts that were deliberately deferred from **PR 1 (#1729)** pending a maintainer decision. Solvi approved handling them in a dedicated PR with per-major scoped pins and its own lockfile audit.

All affected consumers are **dev/build-time tooling** (`eslint` + plugins, `glob`, `avo` CLI, `ignore-walk`, `@typescript-eslint/typescript-estree`, `micromatch`) — none are shipped to docs-site users.

## Changes — scoped `resolutions`, per major

| Package | From | To | Consumer | Clears |
| -- | -- | -- | -- | -- |
| `picomatch` | 2.3.1 | **2.3.2** | `micromatch` | CVE-2026-33671 |
| `minimatch` | 3.1.2 | **3.1.4** | eslint tree + `glob` | CVE-2026-27903/-27904 |
| `minimatch` | 5.1.6 | **5.1.8** | `ignore-walk` | CVE-2026-27903/-27904 |
| `minimatch` | 7.4.6 | **7.4.8** | `avo` | CVE-2026-27903/-27904 |
| `minimatch` | 9.0.5 | **9.0.9** | `@typescript-eslint/typescript-estree` | CVE-2026-27903/-27904 |

The safe `picomatch` **4.0.2 / 4.0.3** copies (via `tinyglobby` / `cspell-glob`) are left untouched.

## `minimatch` 9.x → 9.0.9 (the deferred red-flag, now resolved)

PR 1 flagged that `minimatch@9.0.7` pulls `brace-expansion@^5 → balanced-match@^4 → jackspeak` — a foundational zero-dep utility suddenly acquiring an unrelated CLI-args parser. Verified on the registry: **9.0.7 and 9.0.8 both carry that chain; 9.0.9 (published 2026-02-26) reverts to `brace-expansion@^2.0.2`, so the chain is gone.** Pinned to **9.0.9 exactly** — not 9.0.7/9.0.8.

## Yarn 1 mechanism note

`minimatch` coexists at four majors and `picomatch` at two, each needed at a different version. Yarn 1 could not express this cleanly (which is why PR 1 deferred it):

- a **bare** `"minimatch"` resolution collapses *all* majors to one version (breaks the 5/7/9 consumers);
- plain **parent-scoped** keys (`"ignore-walk/minimatch"`) do **not** bind nested consumers — Yarn 1 resolution paths are rooted at the top-level package;
- **range-qualified** keys (`"minimatch@^5.0.1"`) are unsupported (parsed as a literal version).

Only the **`**/<parent>/<pkg>`** rooted-glob form binds each vulnerable major to its patch without disturbing the safe copies. Verified on disk — exactly four `minimatch` nodes (3.1.4 / 5.1.8 / 7.4.8 / 9.0.9) and the vulnerable `picomatch` at 2.3.2.

## Verification

- **Every target verified against the registry:** publish age > 7 days, not deprecated, no `preinstall`/`install`/`postinstall` scripts (`prepare` only, which registry installs don't run), dependency-delta clean.
- **Post-install lockfile audit:** only `minimatch`, `picomatch`, and `brace-expansion` changed. The new `brace-expansion@2.1.1` (pulled by `minimatch` 7.4.8/9.0.9's `^2.0.2`) stays on the clean `2.x → balanced-match@^1.0.0` chain (published 2026-05-25, no install scripts). Every `resolved` URL on `registry.yarnpkg.com`/`registry.npmjs.org`; integrity hashes intact; **zero packages added**; `jackspeak` / `balanced-match@4` / `brace-expansion@5` confirmed **absent**.
- `yarn build` ✅ · `yarn lint` ✅ · `yarn spellcheck` ✅ (164 files, 0 issues)

> **Note:** the protocol's live alert re-pull (`gh api .../dependabot/alerts`) was not available in this session (GitHub REST is not enabled for the agent); this PR relied on the brief's alert list (verified 2026-07-06) plus the per-package registry verification above.

## Merge ordering

Independent of #1729 and the Next 15 PR (touches only `picomatch`/`minimatch` `resolutions`). If merged after #1729, expect a trivial `resolutions`-block union in `package.json`.

---
_Generated by [Claude Code](https://claude.ai/code/session_018xytCgBQ6DmXUEMKWbKKBH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned several indirect dependencies to specific versions to improve consistency across installs and reduce unexpected version drift.
  * Helped make builds and tooling behavior more stable and predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->