### PR TITLE
Docs: mark "Is Property Required?" import column as optional (AVO-3394)

### DIFF
--- a/pages/publishing/import/importing.mdx
+++ b/pages/publishing/import/importing.mdx
@@ -160,7 +160,7 @@ You can learn more about common Tracking Plan spreadsheet formats [on our blog.]
 | Property Name                | The name of a property that should be sent                        | Any string                            | Device Type                                |
 | Property Description         | The description of the property                                   | Any string                            | The type of client user is currently using |
 | Property Value Type          | The type of the property                                          | string, int, float, bool, object, any | string                                     |
-| Is Property Required?        | True if the property should always be sent with your event        | true, false                           | true                                       |
+| Is Property Required?        | True if the property should always be sent with your event. Optional — defaults to `true` when the column is omitted | true, false                           | true                                       |
 | Is Property Array?           | True if property should be array of values                        | true, false                           | false                                      |
 | Property Enumeration Options | Finite list of all values allowed for the property, if applicable | Comma separated strings               | iOS, Android, Web, Desktop, Fire           |
 


### PR DESCRIPTION
Companion to [avohq/monorepo#9923](https://github.com/avohq/monorepo/pull/9923).

Avo Format CSV import now defaults the property-required flag to `true` when the `Is Property Required?` column is absent (instead of silently dropping every property). This updates the import column reference in `pages/publishing/import/importing.mdx` to note the column is optional and defaults to `true` when omitted.

Link to related task: [AVO-3394](https://linear.app/avo/issue/AVO-3394/csv-import-silently-drops-every-property-when-is-property-required)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EsEmMnyS21KdN6d7J63Wd3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Avo tracking plan CSV template to clarify that `Is Property Required?` defaults to `true` when omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->