### PR TITLE
Clarify how "Only impacted by breaking changes" interacts with workspace approval

### DIFF
--- a/pages/data-design/guides/managing-changes-impacting-multiple-stakeholders.mdx
+++ b/pages/data-design/guides/managing-changes-impacting-multiple-stakeholders.mdx
@@ -97,8 +97,17 @@ These changes appear in your branch's diff and activity log, but they do **not**
 
 Three stakeholder team settings adjust the rules above. They are available on the [Enterprise Plan](http://avo.app/pricing) and are configured per stakeholder team in [stakeholder team settings](/workspace-management/domains#stakeholder-team-settings).
 
-- **Only impacted by breaking changes** – the team is left out of the impacted list for anything marked Non-breaking in the tables above, and is not required to review it.
+- **Only impacted by breaking changes** – the team is not added as a required reviewer when everything the branch changes for them is Non-breaking. It affects the review requirement only: the team still appears in the impacted stakeholders list, each impacted item is labelled Breaking or Non-breaking there, and Slack notifications are unaffected.
 - **Impacted by new items** and **Impacted by PII changes** – these work in the opposite direction: the team is marked impacted whenever the branch adds a new event or property, or changes a PII declaration, **anywhere in the tracking plan** – even on items they are not a stakeholder or owner of. Note that a PII declaration change on its own does not otherwise count as an impacting change.
+
+#### With "Require approval from owning stakeholders" enabled
+
+The workspace setting and the team setting answer different questions, and a team is only required to review when both say yes.
+
+- **The workspace setting decides who is pulled in.** With it enabled, every impacted *owner* team is added as a required reviewer, regardless of what that team chose in its own notification settings. It does not apply to teams that are stakeholders but not owners – those still follow their own **When impacted as stakeholder** setting.
+- **The team setting decides whether the change counts as impact in the first place.** If a team has *Only impacted by breaking changes* enabled and the branch only makes Non-breaking changes to its items, the team is not required to review – even under the workspace requirement.
+
+In short: the workspace setting makes review the default for owning teams across all changes, and each team can narrow that to breaking changes only. Note that for an **owner** team, only the items it *owns* count towards that decision. A team that owns an item receiving a Non-breaking change, and is merely a stakeholder on another item receiving a Breaking one, is not required to review.
 
 ## Minimizing stakeholder impact
 


### PR DESCRIPTION
Follow-up to #1733, prompted by a customer question: *"If we have 'Require approval from owning stakeholders' enabled at a workspace level, how does the stakeholder setting 'Only impacted by breaking changes' work?"*

## Two changes

**1. Fixes an inaccuracy in #1733.** That PR described *Only impacted by breaking changes* as leaving the team out of the impacted list. It does not. `ignoreNonBreakingImpactsForReview` is only read by `GetSpecificDomainRequiredReviewersUseCase` — the impacted-stakeholders list still shows the team (`GetImpactedDomainsUseCase` deliberately does not tier-filter, so the UI can render it), `BranchBar__Dropdown` adds per-item Breaking / Non-breaking labels for exactly these teams, and `ShouldSendDomainNotificationUseCase` never reads the setting, so Slack notifications are unaffected.

**2. Documents the interaction with the workspace setting**, which the guide did not cover:

- The workspace setting decides *who is pulled in* — it ORs into `shouldRequireReview` for impacted **owner** teams only, overriding their own notification setting. Stakeholder-but-not-owner teams still follow their own setting.
- The team setting decides *whether the change counts as impact* — `passesNonBreakingFilter` is ANDed after, for both the owner and stakeholder buckets, so it applies even under the workspace requirement.
- For an owner team the filter reads `maxOwnerTier` — only owned items count. A team owning a Non-breaking change and merely stakeholding a Breaking one is not required to review.

## Note for the product team

The in-product copy under the workspace toggle says *"This overrides individual stakeholder review settings"*. That holds for the notification setting (a `#doNothing` choice is overridden for owners) but not for *Only impacted by breaking changes*, which still filters. Worth a follow-up ticket to narrow that sentence.

`yarn spellcheck` passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how the “Only impacted by breaking changes” setting affects team review requirements.
  * Explained that excluded teams remain listed as impacted stakeholders and continue receiving change labels and Slack notifications.
  * Documented how workspace- and team-level settings combine to determine review requirements, including owner-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->