### PR TITLE
Document the custom fields &amp; PII paywall on the import API

### DIFF
--- a/pages/reference/public-api/import-tracking-plan.mdx
+++ b/pages/reference/public-api/import-tracking-plan.mdx
@@ -184,7 +184,7 @@ The format produced by Avo's [JSON Schema export](/reference/public-api/export-t
 | `customFields` | object | Event custom field values | Only values for [custom fields](/data-design/avo-tracking-plan/governance/custom-fields) that already exist in the workspace; unknown field names are skipped with a warning |
 | `pii` | object | **Not imported** | The event-level `pii` object (`containsPii`, `piiTypes`) is computed from the PII status of the event's properties, never set directly |
 
-> **Note on governance fields:** Custom field values and PII status are only applied for custom field and [PII type](/data-design/avo-tracking-plan/governance/tagging-pii) definitions that already exist in the workspace. Imports never create new definitions. The event-level `pii` object is ignored on import — it's recomputed from the PII status of the event's properties.
+> **Note on governance fields:** Custom fields and PII require a plan that includes them — an import carrying `customFields` or property-level `pii` on a workspace without that plan is rejected with a `403` (see [Error Responses](#error-responses)). On an entitled workspace, values are only applied for custom field and [PII type](/data-design/avo-tracking-plan/governance/tagging-pii) definitions that already exist in the workspace. Imports never create new definitions. The event-level `pii` object is ignored on import — it's recomputed from the PII status of the event's properties.
 
 #### Type Mapping
 
@@ -214,8 +214,8 @@ The format produced by Avo's [JSON Schema export](/reference/public-api/export-t
 | System Property (fallback) | `isSystemProperty` | Boolean; used when `x-avo-sendAs` is absent |
 | Name Mapping | `nameMapping` | Array of `{ "name": "...", "destinationId": "..." }` |
 | Property ID | `id` | Preserved from Avo exports for re-import deduplication |
-| PII Status | `pii` | Object with `isPii` and optionally `piiType` (the [PII type](/data-design/avo-tracking-plan/governance/tagging-pii) name); key absent means Undeclared. PII types must already exist in the workspace — unknown types are skipped with a warning |
-| Custom Fields | `customFields` | [Custom field](/data-design/avo-tracking-plan/governance/custom-fields) values for existing field definitions — unknown field names are skipped with a warning, never auto-created |
+| PII Status | `pii` | Object with `isPii` and optionally `piiType` (the [PII type](/data-design/avo-tracking-plan/governance/tagging-pii) name); key absent means Undeclared. Requires a plan that includes custom fields & PII. PII types must already exist in the workspace — unknown types are skipped with a warning |
+| Custom Fields | `customFields` | [Custom field](/data-design/avo-tracking-plan/governance/custom-fields) values for existing field definitions — requires a plan that includes custom fields & PII; unknown field names are skipped with a warning, never auto-created |
 
 #### Composition Keywords
 
@@ -325,7 +325,7 @@ On success, the API returns a JSON object with the import results:
 | :-- | :-- |
 | 400 | Invalid Content-Type, unparsable body, invalid JSON Schema structure |
 | 401 | Authentication failure |
-| 403 | Protected main branch |
+| 403 | Protected main branch, or the payload carries custom field values or PII status on a workspace whose plan doesn't include custom fields & PII |
 | 404 | Branch not found |
 | 409 | Branch merged/closed, or no prior actions on branch |
 | 500 | Unexpected error |
@@ -338,6 +338,18 @@ All error responses include a `warnings` array for consistent shape:
   "warnings": []
 }
 ```
+
+A `403` caused by the custom fields & PII plan gate also carries a machine-readable `code`, so it can be told apart from the other `403`s without matching on the message:
+
+```json
+{
+  "message": "Custom field values and PII state are not available on this workspace's plan. Upgrade the workspace plan, or remove the custom field and PII columns from the import.",
+  "warnings": [],
+  "code": "paywall_blocked"
+}
+```
+
+Nothing is applied when an import is rejected — the whole payload is refused, not partially imported.
 
 ### Warnings
 


### PR DESCRIPTION
## What changed?

Documents a new customer-visible behaviour of the public import API, shipping in [avohq/monorepo#9932](https://github.com/avohq/monorepo/pull/9932) ([AVO-3401](https://linear.app/avo/issue/AVO-3401/remove-customfieldsandpii-and-stakeholderautoreviewtriggers-feature)): an import carrying custom field values or property PII status is now rejected when the workspace's plan doesn't include custom fields &amp; PII, matching what `save_items` already does for the same content.

All changes are in `pages/reference/public-api/import-tracking-plan.mdx`:

- **Error Responses** — the `403` row now names the paywall alongside the protected-main-branch case, followed by the `paywall_blocked` body shape and a note that nothing is applied when an import is rejected.
- **Note on governance fields** — leads with the plan requirement and links to the error table; the existing "definitions must already exist / imports never create them" wording is unchanged and now scoped to an entitled workspace.
- **Supported Property Features** — the `pii` and `customFields` rows note the plan requirement next to the existing skipped-with-a-warning behaviour.

No new pages, no navigation changes.

## How to test this PR:

- Open `/reference/public-api/import-tracking-plan` and check the Error Responses table, the JSON example under it, and the two governance rows in Supported Property Features.
- The in-page link from the governance note to `#error-responses` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JQSoQmFGnYX5hQF1c7VbB

---
_Generated by [Claude Code](https://claude.ai/code/session_013JQSoQmFGnYX5hQF1c7VbB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified plan requirements for importing custom fields and personally identifiable information.
  * Documented additional `403` error scenarios and added a machine-readable paywall response example.
  * Explained that rejected imports are not partially applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->